### PR TITLE
Optimize slow page loads: fix N+1, OFFSET, caching, indexes

### DIFF
--- a/opds_catalog/feeds.py
+++ b/opds_catalog/feeds.py
@@ -232,14 +232,20 @@ class CatalogsFeed(AuthFeed):
         items = []
         
         for row in catalogs_list[op.d1_first_pos:op.d1_last_pos+1]:
-            p = {'is_catalog':1, 'title': row.cat_name,'id': row.id, 'cat_type':row.cat_type, 'parent_id':row.parent_id}       
+            p = {'is_catalog':1, 'title': row.cat_name,'id': row.id, 'cat_type':row.cat_type, 'parent_id':row.parent_id}
             items.append(p)
-              
-        for row in books_list[op.d2_first_pos:op.d2_last_pos+1]:
+
+        # Prefetch related rows for the whole page (instead of ~4 queries per book)
+        # and materialise them into the dicts the feed rendering expects.
+        page_books = books_list.prefetch_related('authors', 'genres', 'series', 'bseries_set')
+        for row in page_books[op.d2_first_pos:op.d2_last_pos+1]:
             p = {'is_catalog':0, 'lang_code': row.lang_code, 'filename': row.filename, 'path': row.path, \
                   'registerdate': row.registerdate, 'id': row.id, 'annotation': strip_tags(row.annotation), \
                   'docdate': row.docdate, 'format': row.format, 'title': row.title, 'filesize': row.filesize//1000,
-                  'authors':row.authors.values(), 'genres':row.genres.values(), 'series':row.series.values(), 'ser_no':row.bseries_set.values('ser_no')}
+                  'authors':[{'id': a.id, 'full_name': a.full_name} for a in row.authors.all()],
+                  'genres':[{'id': g.id, 'subsection': g.subsection} for g in row.genres.all()],
+                  'series':[{'id': s.id, 'ser': s.ser} for s in row.series.all()],
+                  'ser_no':[{'ser_no': b.ser_no} for b in row.bseries_set.all()]}
             items.append(p)
             
         return items, cat, op.get_data_dict()            
@@ -468,11 +474,15 @@ class SearchBooksFeed(AuthFeed):
         start = op.d1_first_pos if ((op.d1_first_pos==0) or (not summary_DOUBLES_HIDE)) else op.d1_first_pos-1
         finish = op.d1_last_pos
         
-        for row in books[start:finish+1]:
+        page_books = books.prefetch_related('authors', 'genres', 'series', 'bseries_set')
+        for row in page_books[start:finish+1]:
             p = {'doubles':0, 'lang_code': row.lang_code, 'filename': row.filename, 'path': row.path, \
                   'registerdate': row.registerdate, 'id': row.id, 'annotation': strip_tags(row.annotation), \
                   'docdate': row.docdate, 'format': row.format, 'title': row.title, 'filesize': row.filesize//1000,
-                  'authors':row.authors.values(), 'genres':row.genres.values(), 'series':row.series.values(), 'ser_no':row.bseries_set.values('ser_no')}
+                  'authors':[{'id': a.id, 'full_name': a.full_name} for a in row.authors.all()],
+                  'genres':[{'id': g.id, 'subsection': g.subsection} for g in row.genres.all()],
+                  'series':[{'id': s.id, 'ser': s.ser} for s in row.series.all()],
+                  'ser_no':[{'ser_no': b.ser_no} for b in row.bseries_set.all()]}
             if summary_DOUBLES_HIDE:
                 title = p['title'] 
                 authors_set = {a['id'] for a in p['authors']}         

--- a/opds_catalog/feeds.py
+++ b/opds_catalog/feeds.py
@@ -12,6 +12,7 @@ from opds_catalog import models
 from opds_catalog import settings
 from opds_catalog.middleware import BasicAuthMiddleware
 from opds_catalog.opds_paginator import Paginator as OPDS_Paginator
+from opds_catalog.utils import alphabet_menu
 
 from book_tools.format import mime_detector
 from book_tools.format.mimetype import Mimetype
@@ -871,21 +872,7 @@ class BooksFeed(AuthFeed):
         
     def items(self, obj):
         length, chars = obj
-        if self.lang_code:
-            sql="""select %(length)s as l, substring(search_title,1,%(length)s) as id, count(*) as cnt 
-                   from opds_catalog_book 
-                   where lang_code=%(lang_code)s and search_title like '%(chars)s%%%%'
-                   group by substring(search_title,1,%(length)s)
-                   order by id"""%{'length':length, 'lang_code':self.lang_code, 'chars':chars}
-        else:
-            sql="""select %(length)s as l, substring(search_title,1,%(length)s) as id, count(*) as cnt 
-                   from opds_catalog_book 
-                   where search_title like '%(chars)s%%%%'
-                   group by substring(search_title,1,%(length)s)
-                   order by id"""%{'length':length,'chars':chars}
-          
-        dataset = Book.objects.raw(sql)
-        return dataset
+        return alphabet_menu('opds_catalog_book', 'search_title', self.lang_code, chars)
 
     def item_title(self, item):
         return "%s"%item.id
@@ -929,21 +916,7 @@ class AuthorsFeed(AuthFeed):
         
     def items(self, obj):
         length, chars = obj
-        if self.lang_code:
-            sql="""select %(length)s as l, substring(search_full_name,1,%(length)s) as id, count(*) as cnt 
-                   from opds_catalog_author 
-                   where lang_code=%(lang_code)s and search_full_name like '%(chars)s%%%%'
-                   group by substring(search_full_name,1,%(length)s)
-                   order by id"""%{'length':length, 'lang_code':self.lang_code, 'chars':chars}
-        else:
-            sql="""select %(length)s as l, substring(search_full_name,1,%(length)s) as id, count(*) as cnt 
-                   from opds_catalog_author 
-                   where search_full_name like '%(chars)s%%%%'
-                   group by substring(search_full_name,1,%(length)s) 
-                   order by id"""%{'length':length,'chars':chars}
-          
-        dataset = Author.objects.raw(sql)
-        return dataset
+        return alphabet_menu('opds_catalog_author', 'search_full_name', self.lang_code, chars)
 
     def item_title(self, item):
         return "%s"%item.id
@@ -987,21 +960,7 @@ class SeriesFeed(AuthFeed):
         
     def items(self, obj):
         length, chars = obj
-        if self.lang_code:
-            sql="""select %(length)s as l, substring(search_ser,1,%(length)s) as id, count(*) as cnt 
-                   from opds_catalog_series 
-                   where lang_code=%(lang_code)s and search_ser like '%(chars)s%%%%'
-                   group by substring(search_ser,1,%(length)s) 
-                   order by id"""%{'length':length, 'lang_code':self.lang_code, 'chars':chars}
-        else:
-            sql="""select %(length)s as l, substring(search_ser,1,%(length)s) as id, count(*) as cnt 
-                   from opds_catalog_series 
-                   where search_ser like '%(chars)s%%%%'
-                   group by substring(search_ser,1,%(length)s) 
-                   order by id"""%{'length':length,'chars':chars}
-          
-        dataset = Series.objects.raw(sql)
-        return dataset
+        return alphabet_menu('opds_catalog_series', 'search_ser', self.lang_code, chars)
 
     def item_title(self, item):
         return "%s"%item.id

--- a/opds_catalog/migrations/0011_search_trigram_indexes.py
+++ b/opds_catalog/migrations/0011_search_trigram_indexes.py
@@ -1,0 +1,45 @@
+# Adds pg_trgm GIN indexes to speed up substring/prefix search on the columns
+# used by the search views (search_title__contains / __startswith, etc.).
+# A single GIN trigram index accelerates both LIKE '%term%' and LIKE 'term%',
+# which a plain btree index cannot do for the leading-wildcard case.
+#
+# PostgreSQL only — guarded by connection.vendor so the local sqlite/mysql
+# setups keep working (they just skip these indexes).
+from django.db import migrations
+
+
+# (index_name, table, column)
+PG_TRGM_INDEXES = [
+    ("opds_catalog_book_search_title_trgm", "opds_catalog_book", "search_title"),
+    ("opds_catalog_author_search_name_trgm", "opds_catalog_author", "search_full_name"),
+    ("opds_catalog_series_search_ser_trgm", "opds_catalog_series", "search_ser"),
+]
+
+
+def create_trgm_indexes(apps, schema_editor):
+    if schema_editor.connection.vendor != "postgresql":
+        return
+    schema_editor.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+    for name, table, column in PG_TRGM_INDEXES:
+        schema_editor.execute(
+            'CREATE INDEX IF NOT EXISTS "%s" ON "%s" USING gin ("%s" gin_trgm_ops)'
+            % (name, table, column)
+        )
+
+
+def drop_trgm_indexes(apps, schema_editor):
+    if schema_editor.connection.vendor != "postgresql":
+        return
+    for name, _table, _column in PG_TRGM_INDEXES:
+        schema_editor.execute('DROP INDEX IF EXISTS "%s"' % name)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("opds_catalog", "0010_alter_bookshelf_unique_together"),
+    ]
+
+    operations = [
+        migrations.RunPython(create_trgm_indexes, drop_trgm_indexes),
+    ]

--- a/opds_catalog/migrations/0012_book_catalog_title_index.py
+++ b/opds_catalog/migrations/0012_book_catalog_title_index.py
@@ -1,0 +1,39 @@
+# Composite index for the catalog browse page (/web/catalog and the OPDS
+# CatalogsFeed): Book.objects.filter(catalog=cat).order_by('search_title').
+# Without (catalog_id, search_title) Postgres must filter by catalog and then
+# sort the whole matching set by search_title, which is slow for catalogs that
+# contain many books. With the composite index it does an ordered index range
+# scan and can satisfy LIMIT/OFFSET directly.
+#
+# PostgreSQL only, guarded by connection.vendor (mirrors migration 0011).
+from django.db import migrations
+
+
+INDEX_NAME = "opds_catalog_book_catalog_title"
+TABLE = "opds_catalog_book"
+
+
+def create_index(apps, schema_editor):
+    if schema_editor.connection.vendor != "postgresql":
+        return
+    schema_editor.execute(
+        'CREATE INDEX IF NOT EXISTS "%s" ON "%s" ("catalog_id", "search_title")'
+        % (INDEX_NAME, TABLE)
+    )
+
+
+def drop_index(apps, schema_editor):
+    if schema_editor.connection.vendor != "postgresql":
+        return
+    schema_editor.execute('DROP INDEX IF EXISTS "%s"' % INDEX_NAME)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("opds_catalog", "0011_search_trigram_indexes"),
+    ]
+
+    operations = [
+        migrations.RunPython(create_index, drop_index),
+    ]

--- a/opds_catalog/utils.py
+++ b/opds_catalog/utils.py
@@ -4,6 +4,61 @@
 #
 import unicodedata
 
+from types import SimpleNamespace
+
+from django.core.cache import cache
+from django.db import connection
+
+from constance import config
+
+
+def alphabet_menu(table, column, lang_code, chars):
+    """Alphabet drill-down counts for the "select by substring" pages/feeds.
+
+    For every distinct prefix of length len(chars)+1 that starts with `chars`,
+    return the number of matching rows as SimpleNamespace(id=<prefix>, cnt=<n>,
+    l=<prefix length>). Attribute access works both in templates and in Python
+    (OPDS feeds), and the objects pickle fine for caching.
+
+    The result depends only on (table, column, lang_code, chars) and changes
+    only after a library scan, so it is cached for SOPDS_CACHE_TIME. This turns
+    a full-table GROUP BY over the whole books/authors/series table (previously
+    run on every page load) into a single cached computation.
+
+    `chars`/`lang_code` are user-controlled and passed as bound parameters,
+    which also closes the SQL injection that raw string interpolation allowed.
+    `table`/`column`/`length` come only from our own callers (fixed identifiers).
+    """
+    length = len(chars) + 1
+    cache_key = 'alphabet:%s:%s:%s:%s' % (table, lang_code, length, chars)
+    cached = cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    where = []
+    params = []
+    if lang_code:
+        where.append('lang_code = %s')
+        params.append(lang_code)
+    # Escape LIKE wildcards so a literal % or _ in a prefix matches literally.
+    escaped = chars.replace('\\', '\\\\').replace('%', '\\%').replace('_', '\\_')
+    where.append("%s LIKE %%s ESCAPE '\\'" % column)
+    params.append(escaped + '%')
+    where_sql = ' and '.join(where)
+
+    sql = (
+        "select substr({col}, 1, {length}) as id, count(*) as cnt "
+        "from {tbl} where {where} "
+        "group by substr({col}, 1, {length}) order by id"
+    ).format(col=column, length=length, tbl=table, where=where_sql)
+
+    with connection.cursor() as cursor:
+        cursor.execute(sql, params)
+        result = [SimpleNamespace(id=row[0], cnt=row[1], l=length) for row in cursor.fetchall()]
+
+    cache.set(cache_key, result, config.SOPDS_CACHE_TIME)
+    return result
+
 def translit(s):
     """Russian translit: converts 'привет'->'privet'"""
     assert s is not str, "Error: argument MUST be string"

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,8 @@ python-telegram-bot==13.14
 urllib3==1.26.20
 six==1.16.0
 psycopg2-binary==2.9.10
+# Used by django.core.cache.backends.redis.RedisCache when REDIS_URL is set.
+redis==5.0.8
 uwsgi==2.0.28
 raven==6.10.0
 mcp==1.2.0; python_version >= '3.10'

--- a/sopds/settings.py
+++ b/sopds/settings.py
@@ -52,19 +52,23 @@ INSTALLED_APPS = [
     'raven.contrib.django.raven_compat',
 ]
 
+# NOTE: Full-page caching (UpdateCacheMiddleware + FetchFromCacheMiddleware) is
+# intentionally NOT enabled. Every page embeds per-user content (bookshelf,
+# theme, random book via the sopds_processor context processor), so caching whole
+# responses risks serving one user's page to another. The previous config had
+# UpdateCacheMiddleware writing to a cache that was never read (FetchFromCache was
+# commented out) — pure overhead — so it is removed. Performance-sensitive shared
+# fragments are cached explicitly instead (see sopds_web_backend.views).
 MIDDLEWARE = [
-    'django.middleware.cache.UpdateCacheMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',    
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
     #'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'opds_catalog.middleware.SOPDSLocaleMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    #'django.middleware.cache.CacheMiddleware',
-    #'opds_catalog.middleware.FetchFromCacheMiddleware',
 ]
 
 ROOT_URLCONF = 'sopds.urls'
@@ -133,6 +137,14 @@ else:
 
 
 
+# Reuse DB connections across requests instead of opening a new TCP+auth
+# connection every request. SOPDS issues many small queries per page, so the
+# per-request connection overhead is significant. Skipped for sqlite (local file).
+# NOTE: in production DATABASES is overridden by sopds/private_settings.py, so the
+# same CONN_MAX_AGE is set there too.
+if DATABASES['default']['ENGINE'] != 'django.db.backends.sqlite3':
+    DATABASES['default'].setdefault('CONN_MAX_AGE', 60)
+
 #### SOPDS DATABASE SETTINGS FINISH ####
 
 # Password validation
@@ -165,7 +177,25 @@ USE_I18N = True
 USE_L10N = True
 USE_TZ = True
 
-CACHE_BACKEND = "locmem://"
+# Cache backend. "CACHE_BACKEND" was a Django <1.3 setting and is ignored by
+# modern Django, so previously no cache was really configured. Use Redis when
+# REDIS_URL is provided (shared across all uWSGI workers), otherwise fall back
+# to a per-process in-memory cache for local development.
+if os.getenv('REDIS_URL'):
+    CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.redis.RedisCache',
+            'LOCATION': os.getenv('REDIS_URL'),
+        }
+    }
+else:
+    CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            'LOCATION': 'sopds-locmem',
+        }
+    }
+
 CACHE_MIDDLEWARE_KEY_PREFIX = "sopds"
 
 # Static files (CSS, JavaScript, Images)

--- a/sopds_web_backend/views.py
+++ b/sopds_web_backend/views.py
@@ -2,7 +2,8 @@ from random import randint
 
 from django.shortcuts import render, redirect
 from django.template.context_processors import csrf
-from django.db.models import Count, Min
+from django.core.cache import cache
+from django.db.models import Count, Min, Max, Prefetch
 from django.utils.translation import gettext as _
 from django.contrib.auth import authenticate, login, logout, REDIRECT_FIELD_NAME
 from django.contrib.auth.decorators import user_passes_test
@@ -22,6 +23,12 @@ from opds_catalog.opds_paginator import Paginator as OPDS_Paginator
 
 from sopds_web_backend.settings import HALF_PAGES_LINKS
 from django.http import HttpResponse
+
+
+def theme_css(user):
+    """Return the user's theme css in a single query (instead of exists()+get())."""
+    theme = Theme.objects.filter(user=user).first()
+    return theme.theme_css if theme else "css/sopds.css"
 
 
 def sopds_login(function=None, redirect_field_name=REDIRECT_FIELD_NAME, url=None):
@@ -54,27 +61,39 @@ def sopds_processor(request):
         user = request.user
         if user.is_authenticated:
             result = []
-            for row in bookshelf.objects.filter(user=user).order_by('-readtime')[:8]:
-                book = Book.objects.get(id=row.book_id)
-                p = {'id': row.id, 'readtime': row.readtime, 'book_id': row.book_id, 'title': book.title, 'authors': book.authors.values()}
+            shelf = (bookshelf.objects.filter(user=user)
+                     .select_related('book')
+                     .prefetch_related('book__authors')
+                     .order_by('-readtime')[:8])
+            for row in shelf:
+                book = row.book
+                p = {'id': row.id, 'readtime': row.readtime, 'book_id': row.book_id, 'title': book.title,
+                     'authors': [{'id': a.id, 'full_name': a.full_name} for a in book.authors.all()]}
                 result.append(p)
             args['bookshelf'] = result
-        
-    books_count = Counter.objects.get_counter(models.counter_allbooks)
-    if books_count:
-        random_id = randint(1, books_count)
-        try:
-            random_book = Book.objects.all()[random_id-1:random_id][0]
-        except Book.DoesNotExist:
-            random_book = None
-    else:
+
+    # The stats block and random book are identical for every user and expensive
+    # to compute (a COUNT over all books + a random row lookup), so they run on
+    # every single page render. Cache them for a short period instead.
+    common = cache.get('sopds_processor_common')
+    if common is None:
+        books_count = Counter.objects.get_counter(models.counter_allbooks)
         random_book = None
-                   
-    args['random_book'] = random_book
-    stats = {d['name']: d['value'] for d in Counter.obj.all().values()}
-    stats['lastscan_date'] = Counter.objects.get_lastscan()
-    args['stats'] = stats
-  
+        if books_count:
+            # Avoid LIMIT 1 OFFSET N on a huge table (Postgres physically walks
+            # N rows). Pick a random id and take the first existing row from it.
+            max_id = Book.objects.aggregate(m=Max('id'))['m'] or 0
+            if max_id:
+                random_book = (Book.objects.filter(id__gte=randint(1, max_id)).order_by('id').first()
+                               or Book.objects.order_by('-id').first())
+        stats = {d['name']: d['value'] for d in Counter.obj.all().values()}
+        stats['lastscan_date'] = Counter.objects.get_lastscan()
+        common = {'random_book': random_book, 'stats': stats}
+        cache.set('sopds_processor_common', common, 60)
+
+    args['random_book'] = common['random_book']
+    args['stats'] = common['stats']
+
     return args
 
 
@@ -206,8 +225,18 @@ def SearchBooksView(request):
         summary_DOUBLES_HIDE = config.SOPDS_DOUBLES_HIDE and (searchtype != 'd')
         start = op.d1_first_pos if ((op.d1_first_pos == 0) or (not summary_DOUBLES_HIDE)) else op.d1_first_pos-1
         finish = op.d1_last_pos
-        
-        for row in books[start:finish+1]:
+
+        # Prefetch related rows for the whole page in a handful of queries instead
+        # of ~6 queries per book (authors/genres/series/ser_no/bookshelf x2).
+        prefetch = ['authors', 'genres', 'series', 'bseries_set']
+        if config.SOPDS_AUTH:
+            prefetch.append(Prefetch('bookshelf_set',
+                                     queryset=bookshelf.objects.filter(user=request.user),
+                                     to_attr='user_shelf'))
+        page_books = books.prefetch_related(*prefetch)
+
+        for row in page_books[start:finish+1]:
+            user_shelf = getattr(row, 'user_shelf', []) if config.SOPDS_AUTH else []
             p = {'doubles': 0,
                  'lang_code': row.lang_code,
                  'filename': row.filename,
@@ -219,17 +248,17 @@ def SearchBooksView(request):
                  'format': row.format,
                  'title': row.title,
                  'filesize': row.filesize // 1000,
-                 'authors': row.authors.values(),
-                 'genres': row.genres.values(),
-                 'series': row.series.values(),
-                 'ser_no': row.bseries_set.values('ser_no'),
-                 'bookshelf': row.bookshelf_set.filter(user=request.user).exists() if config.SOPDS_AUTH else False,
-                 'readtime': row.bookshelf_set.filter(user=request.user).values('readtime') if config.SOPDS_AUTH else None
+                 'authors': row.authors.all(),
+                 'genres': row.genres.all(),
+                 'series': row.series.all(),
+                 'ser_no': row.bseries_set.all(),
+                 'bookshelf': bool(user_shelf),
+                 'readtime': user_shelf if config.SOPDS_AUTH else None
                  }
 
             if summary_DOUBLES_HIDE:
                 title = p['title']
-                authors_set = {a['id'] for a in p['authors']}         
+                authors_set = {a.id for a in p['authors']}
                 if title.upper() == prev_title.upper() and authors_set == prev_authors_set:
                     items[-1]['doubles'] += 1
                     if p['bookshelf']:
@@ -265,12 +294,7 @@ def SearchBooksView(request):
             args['cache_t'] = 0
         else:
             args['cache_t'] = config.SOPDS_CACHE_TIME
-        args['css_file'] = Theme.objects.get(user=request.user).theme_css if Theme.objects.filter(user=request.user).exists() else "css/sopds.css"
-
-
-    from pprint import pprint
-    pprint(args)
-
+        args['css_file'] = theme_css(request.user)
 
     return render(request, 'sopds_books.html', args)
 
@@ -278,11 +302,10 @@ def SearchBooksView(request):
 @vary_on_headers("HTTP_ACCEPT_LANGUAGE")
 @sopds_login(url='web:login')
 def ThemeView(request):
-    if Theme.objects.filter(user=request.user).exists():
-        if Theme.objects.get(user=request.user).theme_css == "css/sopds.css":
-            Theme.objects.filter(user=request.user).update(theme_css="css/sopds-dark.css")
-        else:
-            Theme.objects.filter(user=request.user).update(theme_css="css/sopds.css")
+    theme = Theme.objects.filter(user=request.user).first()
+    if theme:
+        theme.theme_css = "css/sopds-dark.css" if theme.theme_css == "css/sopds.css" else "css/sopds.css"
+        theme.save(update_fields=["theme_css"])
     else:
         Theme.objects.create(user=request.user, theme_css="css/sopds-dark.css")
     return HttpResponseRedirect(request.META.get('HTTP_REFERER'))
@@ -331,7 +354,7 @@ def SearchSeriesView(request):
         args['breadcrumbs'] = [_('Series'),_('Search'),searchterms]
         args['cache_id']='%s:%s:%s'%(searchterms,searchtype,op.page_num)
         args['cache_t']=config.SOPDS_CACHE_TIME
-        args['css_file'] = Theme.objects.get(user=request.user).theme_css if Theme.objects.filter(user=request.user).exists() else "css/sopds.css"
+        args['css_file'] = theme_css(request.user)
 
     return render(request, 'sopds_series.html', args)
 
@@ -375,7 +398,7 @@ def SearchAuthorsView(request):
         args['breadcrumbs'] = [_('Authors'), _('Search'),searchterms]
         args['cache_id'] = '%s:%s:%s' % (searchterms, searchtype, op.page_num)
         args['cache_t'] = config.SOPDS_CACHE_TIME
-        args['css_file'] = Theme.objects.get(user=request.user).theme_css if Theme.objects.filter(user=request.user).exists() else "css/sopds.css"
+        args['css_file'] = theme_css(request.user)
 
     return render(request, 'sopds_authors.html', args)
 
@@ -412,15 +435,24 @@ def CatalogsView(request):
     items = []
     
     for row in catalogs_list[op.d1_first_pos:op.d1_last_pos+1]:
-        p = {'is_catalog':1, 'title': row.cat_name,'id': row.id, 'cat_type':row.cat_type, 'parent_id':row.parent_id}       
+        p = {'is_catalog':1, 'title': row.cat_name,'id': row.id, 'cat_type':row.cat_type, 'parent_id':row.parent_id}
         items.append(p)
-          
-    for row in books_list[op.d2_first_pos:op.d2_last_pos+1]:
+
+    # Prefetch related rows for the page instead of ~5 queries per book.
+    prefetch = ['authors', 'genres', 'series', 'bseries_set']
+    if config.SOPDS_AUTH:
+        prefetch.append(Prefetch('bookshelf_set',
+                                 queryset=bookshelf.objects.filter(user=request.user),
+                                 to_attr='user_shelf'))
+    page_books = books_list.prefetch_related(*prefetch)
+
+    for row in page_books[op.d2_first_pos:op.d2_last_pos+1]:
+        user_shelf = getattr(row, 'user_shelf', []) if config.SOPDS_AUTH else []
         p = {'is_catalog':0, 'lang_code': row.lang_code, 'filename': row.filename, 'path': row.path, \
               'registerdate': row.registerdate, 'id': row.id, 'annotation': strip_tags(row.annotation), \
               'docdate': row.docdate, 'format': row.format, 'title': row.title, 'filesize': row.filesize//1000,\
-              'authors':row.authors.values(), 'genres':row.genres.values(), 'series':row.series.values(), 'ser_no':row.bseries_set.values('ser_no'),\
-              'readtime': row.bookshelf_set.filter(user=request.user).values('readtime') if config.SOPDS_AUTH else None
+              'authors':row.authors.all(), 'genres':row.genres.all(), 'series':row.series.all(), 'ser_no':row.bseries_set.all(),\
+              'readtime': user_shelf if config.SOPDS_AUTH else None
              }
         items.append(p)
                     
@@ -440,7 +472,7 @@ def CatalogsView(request):
     args['breadcrumbs'] =  [_('Catalogs')]
     args['cache_id'] = '%s:%s:%s' % (args['current'],cat_id, op.page_num)
     args['cache_t'] = config.SOPDS_CACHE_TIME
-    args['css_file'] = Theme.objects.get(user=request.user).theme_css if Theme.objects.filter(user=request.user).exists() else "css/sopds.css"
+    args['css_file'] = theme_css(request.user)
 
     return render(request, 'sopds_catalogs.html', args)
 
@@ -479,7 +511,7 @@ def BooksView(request):
     args['breadcrumbs'] =  [_('Books'),_('Select'),lang_menu[lang_code],chars]
     args['cache_id'] = '%s:%s:%s' % (args['current'],lang_code, chars)
     args['cache_t'] = config.SOPDS_CACHE_TIME
-    args['css_file'] = Theme.objects.get(user=request.user).theme_css if Theme.objects.filter(user=request.user).exists() else "css/sopds.css"
+    args['css_file'] = theme_css(request.user)
 
     return render(request, 'sopds_selectbook.html', args)
 
@@ -518,8 +550,7 @@ def AuthorsView(request):
     args['breadcrumbs'] =  [_('Authors'),_('Select'),lang_menu[lang_code],chars]
     args['cache_id'] = '%s:%s:%s' % (args['current'],lang_code, chars)
     args['cache_t'] = config.SOPDS_CACHE_TIME
-    args['css_file'] = Theme.objects.get(user=request.user).theme_css if Theme.objects.filter(
-        user=request.user).exists() else "css/sopds.css"
+    args['css_file'] = theme_css(request.user)
 
     return render(request, 'sopds_selectauthor.html', args)
 
@@ -558,8 +589,7 @@ def SeriesView(request):
     args['breadcrumbs'] =  [_('Series'),_('Select'),lang_menu[lang_code],chars]
     args['cache_id'] = '%s:%s:%s' % (args['current'],lang_code, chars)
     args['cache_t'] = config.SOPDS_CACHE_TIME
-    args['css_file'] = Theme.objects.get(user=request.user).theme_css if Theme.objects.filter(
-        user=request.user).exists() else "css/sopds.css"
+    args['css_file'] = theme_css(request.user)
 
     return render(request,'sopds_selectseries.html', args)
 
@@ -587,8 +617,7 @@ def GenresView(request):
     args['parent_id'] = section_id
     args['cache_id'] = '%s:%s' % (args['current'],section_id)
     args['cache_t'] = config.SOPDS_CACHE_TIME
-    args['css_file'] = Theme.objects.get(user=request.user).theme_css if Theme.objects.filter(
-        user=request.user).exists() else "css/sopds.css"
+    args['css_file'] = theme_css(request.user)
 
     return render(request, 'sopds_selectgenres.html', args)
 
@@ -652,8 +681,7 @@ def hello(request):
     args = {}
     args['breadcrumbs'] = [_('HOME')]
     if request.user.is_authenticated:
-        args['css_file'] = Theme.objects.get(user=request.user).theme_css if Theme.objects.filter(
-            user=request.user).exists() else "css/sopds.css"
+        args['css_file'] = theme_css(request.user)
     else:
         args['css_file'] = "css/sopds.css"
     return render(request, 'sopds_hello.html', args)
@@ -705,8 +733,7 @@ def BookReaderView(request, book_id):
     args = {}
     args['current'] = 'reader'
     args['book_id'] = book_id
-    args['css_file'] = Theme.objects.get(user=request.user).theme_css if Theme.objects.filter(
-        user=request.user).exists() else "css/sopds.css"
+    args['css_file'] = theme_css(request.user)
     return render(request, 'BookReader.html', args)
 
 

--- a/sopds_web_backend/views.py
+++ b/sopds_web_backend/views.py
@@ -17,6 +17,7 @@ from django.http import HttpResponseForbidden, HttpResponseRedirect
 from opds_catalog import models
 from opds_catalog.models import Book, Author, Series, bookshelf, Counter, Catalog, Genre, lang_menu, Theme
 from opds_catalog import settings
+from opds_catalog.utils import alphabet_menu
 from constance import config
 from opds_catalog.opds_paginator import Paginator as OPDS_Paginator
 
@@ -489,24 +490,10 @@ def BooksView(request):
         lang_code = 0
         chars = ''
         
-    length = len(chars)+1
-    if lang_code:
-        sql="""select %(length)s as l, substring(search_title,1,%(length)s) as id, count(*) as cnt 
-               from opds_catalog_book 
-               where lang_code=%(lang_code)s and search_title like '%(chars)s%%%%'
-               group by substring(search_title,1,%(length)s) 
-               order by id"""%{'length':length, 'lang_code':lang_code, 'chars':chars}
-    else:
-        sql="""select %(length)s as l, substring(search_title,1,%(length)s) as id, count(*) as cnt 
-               from opds_catalog_book 
-               where search_title like '%(chars)s%%%%'
-               group by substring(search_title,1,%(length)s) 
-               order by id"""%{'length':length,'chars':chars}
-      
-    items = Book.objects.raw(sql)
-          
+    items = alphabet_menu('opds_catalog_book', 'search_title', lang_code, chars.upper())
+
     args['items']=items
-    args['current'] = 'book'      
+    args['current'] = 'book'
     args['lang_code'] = lang_code   
     args['breadcrumbs'] =  [_('Books'),_('Select'),lang_menu[lang_code],chars]
     args['cache_id'] = '%s:%s:%s' % (args['current'],lang_code, chars)
@@ -528,24 +515,10 @@ def AuthorsView(request):
         lang_code = 0
         chars = ''
         
-    length = len(chars)+1
-    if lang_code:
-        sql="""select %(length)s as l, substring(search_full_name,1,%(length)s) as id, count(*) as cnt 
-               from opds_catalog_author 
-               where lang_code=%(lang_code)s and search_full_name like '%(chars)s%%%%'
-               group by substring(search_full_name,1,%(length)s) 
-               order by id"""%{'length':length, 'lang_code':lang_code, 'chars':chars}
-    else:
-        sql="""select %(length)s as l, substring(search_full_name,1,%(length)s) as id, count(*) as cnt 
-               from opds_catalog_author 
-               where search_full_name like '%(chars)s%%%%'
-               group by substring(search_full_name,1,%(length)s) 
-               order by id"""%{'length':length,'chars':chars}
-      
-    items = Author.objects.raw(sql)
-          
+    items = alphabet_menu('opds_catalog_author', 'search_full_name', lang_code, chars.upper())
+
     args['items']=items
-    args['current'] = 'author'      
+    args['current'] = 'author'
     args['lang_code'] = lang_code   
     args['breadcrumbs'] =  [_('Authors'),_('Select'),lang_menu[lang_code],chars]
     args['cache_id'] = '%s:%s:%s' % (args['current'],lang_code, chars)
@@ -567,24 +540,10 @@ def SeriesView(request):
         lang_code = 0
         chars = ''
         
-    length = len(chars)+1
-    if lang_code:
-        sql="""select %(length)s as l, substring(search_ser,1,%(length)s) as id, count(*) as cnt 
-               from opds_catalog_series 
-               where lang_code=%(lang_code)s and search_ser like '%(chars)s%%%%'
-               group by substring(search_ser,1,%(length)s)
-               order by id"""%{'length':length, 'lang_code':lang_code, 'chars':chars}
-    else:
-        sql="""select %(length)s as l, substring(search_ser,1,%(length)s) as id, count(*) as cnt 
-               from opds_catalog_series 
-               where search_ser like '%(chars)s%%%%'
-               group by substring(search_ser,1,%(length)s) 
-               order by id"""%{'length':length,'chars':chars}
-      
-    items = Series.objects.raw(sql)
-          
+    items = alphabet_menu('opds_catalog_series', 'search_ser', lang_code, chars.upper())
+
     args['items']=items
-    args['current'] = 'series'      
+    args['current'] = 'series'
     args['lang_code'] = lang_code   
     args['breadcrumbs'] =  [_('Series'),_('Select'),lang_menu[lang_code],chars]
     args['cache_id'] = '%s:%s:%s' % (args['current'],lang_code, chars)


### PR DESCRIPTION
Fixes slow load times across the sopds web UI and OPDS feeds. Almost every page was slow due to a combination of N+1 queries, expensive `OFFSET`/full-table scans run on every request, an effectively disabled cache, and a leftover debug `pprint` in production.

## Query / view fixes
- **`sopds_processor`** (runs on every page): pick the random book by id instead of `LIMIT 1 OFFSET N`; cache the shared stats + random-book block for 60s; drop the bookshelf N+1 via `select_related`/`prefetch_related`.
- **`SearchBooksView` / `CatalogsView` + OPDS feeds**: restore `prefetch_related` for authors/genres/series/bseries/bookshelf instead of ~6 queries per book; the per-user bookshelf is fetched via `Prefetch(..., to_attr=...)`.
- **`/web/book`, `/web/author`, `/web/series`** (and their OPDS feeds): the alphabet menu ran a full-table `GROUP BY substr(search_*, 1, N)` on every request. Extracted into a cached, parametrized helper `opds_catalog.utils.alphabet_menu` — the result depends only on `(table, lang_code, chars)` and changes only after a scan, so it is cached for `SOPDS_CACHE_TIME`. Parametrizing `chars`/`lang_code` also **closes the SQL injection** that raw string interpolation allowed.
- Remove the leftover debug `pprint(args)` from `SearchBooksView`.
- Resolve the CSS theme in a single query (`theme_css` helper) instead of `exists()` + `get()`.

## Caching / connections
- Configure a real `CACHES` backend (Redis when `REDIS_URL` is set, locmem fallback). The old `CACHE_BACKEND = "locmem://"` was a pre-1.3 setting ignored by modern Django.
- Drop the write-only `UpdateCacheMiddleware` (it wrote to a cache that was never read, since `FetchFromCacheMiddleware` was commented out).
- Add `CONN_MAX_AGE` so DB connections are reused across requests.
- Add the `redis` dependency.

## Indexes (migrations)
- `0011`: GIN `pg_trgm` indexes on `search_title` / `search_full_name` / `search_ser` for substring/prefix search.
- `0012`: composite index `(catalog_id, search_title)` so `/web/catalog` and `CatalogsFeed` do an ordered index range scan instead of filter-then-sort.

Both migrations are PostgreSQL-only (guarded by `connection.vendor`) and use `IF NOT EXISTS`, so they are no-ops on sqlite/mysql and safe to re-run.

## Notes
- Full-page caching is intentionally **not** enabled: pages embed per-user content (bookshelf/theme/random book), and `FetchFromCacheMiddleware` does not key the cache per user, so it would risk serving one user's page to another. Only shared, user-independent data is cached.
- `alphabet_menu` fills the cache lazily; after a library scan stale counts live until the TTL expires. If instant freshness is needed, the scanner can clear these keys at the end of a scan.
- The infrastructure side (uwsgi tuning, resource bumps, Redis via the cluster's redis-operator, `REDIS_URL`, `CONN_MAX_AGE` in the prod settings) lives in the **sopds-k8s** repo.
- The sopds-k8s `werf.yaml` image pin already points at this branch's tip, so it is deployable as-is; after this PR merges, repoint it to the resulting `master` commit.