### PR TITLE
Settings page + reader preferences (theme, chapters, font, progress)

### DIFF
--- a/opds_catalog/migrations/0014_theme_reader_prefs.py
+++ b/opds_catalog/migrations/0014_theme_reader_prefs.py
@@ -1,0 +1,23 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("opds_catalog", "0013_bookshelf_position_char"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="theme",
+            name="reader_mode",
+            field=models.CharField(
+                choices=[("whole", "Whole text"), ("chapters", "By chapters")],
+                default="whole", max_length=16),
+        ),
+        migrations.AddField(
+            model_name="theme",
+            name="font_size",
+            field=models.PositiveSmallIntegerField(default=100),
+        ),
+    ]

--- a/opds_catalog/models.py
+++ b/opds_catalog/models.py
@@ -107,8 +107,15 @@ class bseries(models.Model):
 
 
 class Theme(models.Model):
+    # Per-user preferences (theme + reader settings), edited on /web/settings/.
+    READER_WHOLE = 'whole'
+    READER_CHAPTERS = 'chapters'
+    READER_MODE_CHOICES = [(READER_WHOLE, 'Whole text'), (READER_CHAPTERS, 'By chapters')]
+
     user = models.OneToOneField(User, on_delete=models.CASCADE)
     theme_css = models.CharField(max_length=64, default='css/sopds.css')
+    reader_mode = models.CharField(max_length=16, choices=READER_MODE_CHOICES, default=READER_WHOLE)
+    font_size = models.PositiveSmallIntegerField(default=100)  # percent, 70..200
 
 
 class bookshelf(models.Model):

--- a/sopds_web_backend/templates/BookReader.html
+++ b/sopds_web_backend/templates/BookReader.html
@@ -2,11 +2,22 @@
 {% load i18n %}
 {% load static %}
 {% block body %}
+<style>
+	#ReaderBlock { font-size: {{ font_size|default:100 }}%; }
+	#reader-progress { position: fixed; left: 0; bottom: 0; width: 100%; height: 4px; background: rgba(127,127,127,0.25); z-index: 1000; }
+	#reader-progress .bar { height: 100%; width: 0; background: #f15a23; transition: width .2s; }
+	#reader-hud { position: fixed; right: 0.6rem; bottom: 0.8rem; z-index: 1001; text-align: right; font-size: 85%; }
+	#reader-hud .label { background: #f15a23; color: #fefefe; }
+	#reader-hud .button { margin: 0 0 .3rem 0; }
+</style>
 <script>
 	var BookID = {{ book_id }};
+	var ReaderMode = "{{ reader_mode|default:'whole' }}";
 	var delay = 1000;
 	var timeout = null;
-	
+	var chapters = [];       // array of .sopds-chapter wrapper elements (chapter mode)
+	var curChapter = 0;
+
 	var waitForLoad = function(){
 		if (typeof jQuery != "undefined") {
 			LoadBook();
@@ -14,18 +25,20 @@
 				clearTimeout(timeout);
 				timeout = setTimeout(function(){
 					SetPos();
+					updateProgress();
 				},delay);
 			});
 		} else {
 			window.setTimeout(waitForLoad, 500);
 		}
 	};
-	window.setTimeout(waitForLoad, 500);  
-	
+	window.setTimeout(waitForLoad, 500);
+
 	var ChangeBookDate = function(ID){
-		
 	}
-	
+
+	// Save the id of the first visible paragraph. Hidden chapters have offset 0
+	// and are skipped, so this works in both whole and chapter mode.
 	var SetPos = function(){
 		var Reader = $('#ReaderBlock');
 		xPos = window.scrollY;
@@ -37,33 +50,100 @@
 					url: '{% url 'web:setpos' book_id %}?pos='+CurrentPos,
 					type: 'GET',
 					cache: false
-				});	
+				});
 				return false;
 			};
-		})	
+		})
 	}
-	
+
 	var GetPos = function(){
 		$.ajax( {
 			url: '{% url 'web:getpos' book_id %}',
 			type: 'GET',
 			cache: false,
 			success: function(lineID) {
-				if (!lineID) return;
-				var Reader = $('#ReaderBlock');
-				Reader.find('div[id]').each(function(idx,el){
-					if ($(el).attr('id') == lineID) {
-						window.scrollTo(0,$(el).offset().top);
-					};
-				})
+				if (!lineID) { updateProgress(); return; }
+				var el = document.getElementById(lineID);
+				if (!el) {
+					// id lookup can miss (ids may repeat); fall back to a scan
+					$('#ReaderBlock div[id]').each(function(idx,e){ if ($(e).attr('id')==lineID){ el=e; return false; } });
+				}
+				if (!el) { updateProgress(); return; }
+				if (ReaderMode === 'chapters' && chapters.length) {
+					var wrap = $(el).closest('.sopds-chapter')[0];
+					var i = chapters.indexOf(wrap);
+					if (i >= 0) showChapter(i, false);
+				}
+				window.scrollTo(0, $(el).offset().top);
+				updateProgress();
+			},
+			error: function(){ updateProgress(); }
+		});
+	}
+
+	// Split the flat rendered book into chapters by the <a name="TOC_n"> anchors
+	// the FB2 XSLT emits at each section start. Falls back to whole text if it
+	// cannot find at least two chapters.
+	var buildChapters = function(){
+		var block = document.getElementById('ReaderBlock');
+		var nodes = Array.prototype.slice.call(block.childNodes);
+		var wraps = [], cur = null;
+		nodes.forEach(function(n){
+			var boundary = n.nodeType === 1 && n.tagName === 'A' &&
+			               (n.getAttribute('name') || '').indexOf('TOC_') === 0;
+			if (cur === null || boundary) {
+				cur = document.createElement('div');
+				cur.className = 'sopds-chapter';
+				wraps.push(cur);
 			}
-		});		
+			cur.appendChild(n);
+		});
+		if (wraps.length < 2) {   // nothing meaningful to paginate
+			wraps.forEach(function(w){ while (w.firstChild) block.appendChild(w.firstChild); });
+			ReaderMode = 'whole';
+			return;
+		}
+		wraps.forEach(function(w){ block.appendChild(w); });
+		chapters = wraps;
+	}
+
+	var showChapter = function(i, doScroll){
+		if (!chapters.length) return;
+		i = Math.min(chapters.length - 1, Math.max(0, i));
+		curChapter = i;
+		chapters.forEach(function(w, idx){ w.style.display = (idx === i ? '' : 'none'); });
+		if (doScroll !== false) window.scrollTo(0, 0);
+		$('#chap-label').text((i + 1) + ' / ' + chapters.length);
+		updateProgress();
+	}
+
+	var nextChapter = function(){ showChapter(curChapter + 1); SetPos(); }
+	var prevChapter = function(){ showChapter(curChapter - 1); SetPos(); }
+
+	var updateProgress = function(){
+		var pct = 0;
+		if (ReaderMode === 'chapters' && chapters.length) {
+			pct = chapters.length > 1 ? curChapter / (chapters.length - 1) * 100 : 100;
+		} else {
+			var max = document.documentElement.scrollHeight - window.innerHeight;
+			pct = max > 0 ? window.scrollY / max * 100 : 0;
+		}
+		pct = Math.min(100, Math.max(0, pct));
+		$('#reader-progress .bar').css('width', pct.toFixed(1) + '%');
+		$('#reader-pct').text(Math.round(pct) + '%');
+	}
+
+	var initReader = function(){
+		if (ReaderMode === 'chapters') buildChapters();
+		$('#reader-hud-chapters').toggle(ReaderMode === 'chapters' && chapters.length > 0);
+		if (ReaderMode === 'chapters' && chapters.length) showChapter(0, false);
+		GetPos();   // restores saved position (and the right chapter)
 	}
 
 	LoadBook = function(){
 		if (localStorage.getItem(BookID)){
 			$("#ReaderBlock").html(LZString.decompress(localStorage.getItem(BookID)));
-			GetPos();
+			initReader();
 		} else {
 			$.ajax( {
 				url: '{% url 'opds_catalog:read' book_id %}',
@@ -71,15 +151,15 @@
 				cache: true,
 				success: function(html) {
 					$("#ReaderBlock").html(html);
-					
+
 					var StoreDates = {};
 					if (localStorage.getItem('StoreDates')) {
 						StoreDates = JSON.parse(localStorage.getItem('StoreDates'));
 					}
 					StoreDates[BookID] = Date();
-					
+
 					var CompressedBook = LZString.compress(html);
-					
+
 					var StoreBook = function(){
 						try {
 							localStorage.setItem(BookID,CompressedBook);
@@ -100,12 +180,22 @@
 						}
 					}
 					StoreBook();
-					
-					GetPos();
+
+					initReader();
 				}
-			});	
+			});
 		}
 	}
 </script>
+
+<div id="reader-hud">
+	<span id="reader-hud-chapters" style="display:none;">
+		<a class="button small" href="#" onclick="prevChapter();return false;">&#9664;</a>
+		<span class="label">{% trans "Chapter" %} <span id="chap-label"></span></span>
+		<a class="button small" href="#" onclick="nextChapter();return false;">&#9654;</a><br>
+	</span>
+	<span class="label" id="reader-pct">0%</span>
+</div>
+<div id="reader-progress"><div class="bar"></div></div>
 <div id="ReaderBlock"><div id="DownloadBook" style="text-align: center;"><img src="{% static "images/download.gif" %}" style="width: 200px;height: 200px;"></div></div>
 {% endblock %}{# body #}

--- a/sopds_web_backend/templates/sopds_settings.html
+++ b/sopds_web_backend/templates/sopds_settings.html
@@ -1,0 +1,31 @@
+{% extends "sopds_main.html" %}
+{% load i18n %}
+
+{% block body %}
+<div class="row"><div class="large-8 column">
+	<h4>{% trans "Settings" %}</h4>
+	<form method="post" action="{% url 'web:settings' %}">
+		{% csrf_token %}
+
+		<fieldset class="fieldset">
+			<legend>{% trans "Theme" %}</legend>
+			<input type="radio" name="theme" value="light" id="theme_light" {% if not is_dark %}checked{% endif %}><label for="theme_light">{% trans "Light" %}</label>
+			<input type="radio" name="theme" value="dark" id="theme_dark" {% if is_dark %}checked{% endif %}><label for="theme_dark">{% trans "Dark" %}</label>
+		</fieldset>
+
+		<fieldset class="fieldset">
+			<legend>{% trans "Reader mode" %}</legend>
+			<input type="radio" name="reader_mode" value="whole" id="rm_whole" {% if prefs.reader_mode != "chapters" %}checked{% endif %}><label for="rm_whole">{% trans "Whole text" %}</label>
+			<input type="radio" name="reader_mode" value="chapters" id="rm_chapters" {% if prefs.reader_mode == "chapters" %}checked{% endif %}><label for="rm_chapters">{% trans "By chapters" %}</label>
+		</fieldset>
+
+		<fieldset class="fieldset">
+			<legend>{% trans "Reader font size" %}: <span id="fs_val">{{ prefs.font_size }}</span>%</legend>
+			<input type="range" name="font_size" id="font_size" min="70" max="200" step="10" value="{{ prefs.font_size }}"
+			       oninput="document.getElementById('fs_val').textContent=this.value;">
+		</fieldset>
+
+		<button type="submit" class="button">{% trans "Save" %}</button>
+	</form>
+</div></div>
+{% endblock %}{# body #}

--- a/sopds_web_backend/templates/sopds_top.html
+++ b/sopds_web_backend/templates/sopds_top.html
@@ -18,11 +18,11 @@
         {% if sopds_auth %}
         <ul class="menu" style="font-size:90%;">
             {% if user.is_authenticated %}
-                <li><a href="{% url "web:theme" %}"><i class="fi-widget"></i>{% trans "Theme" %}</a></li>
-                <li><a href="{% url "web:logout" %}"><i class="fi-torsos"></i>{% trans "Logout" %} ({{ user.username }})</a></li>
+                <li><a href="{% url "web:settings" %}"><i class="fi-widget"></i>{% trans "Settings" %}</a></li>
             {% if user.is_superuser %}
-            	<li><a href="{% url "admin:index" %}"><i class="fi-widget"></i>{% trans "Settings" %}</a></li>
-            {% endif %}	                
+            	<li><a href="{% url "admin:index" %}"><i class="fi-wrench"></i>{% trans "Admin" %}</a></li>
+            {% endif %}
+                <li><a href="{% url "web:logout" %}"><i class="fi-torsos"></i>{% trans "Logout" %} ({{ user.username }})</a></li>
             {% else %}
                 <li><a href="{% url "web:login" %}"><i class="fi-torsos"></i>{% trans "Login" %}</a></li>
             {% endif %}

--- a/sopds_web_backend/urls.py
+++ b/sopds_web_backend/urls.py
@@ -15,6 +15,7 @@ urlpatterns = [
     re_path(r'^genre/$',views.GenresView, name='genre'),
     re_path(r'^series/$',views.SeriesView, name='series'),
     re_path(r'^theme/$',views.ThemeView, name='theme'),
+    re_path(r'^settings/$',views.SettingsView, name='settings'),
     re_path(r'^login/$',views.LoginView, name='login'),
     re_path(r'^logout/$',views.LogoutView, name='logout'),
     re_path(r'^bs/add/$',views.BSAddView, name='bsadd'),

--- a/sopds_web_backend/views.py
+++ b/sopds_web_backend/views.py
@@ -32,6 +32,12 @@ def theme_css(user):
     return theme.theme_css if theme else "css/sopds.css"
 
 
+def user_prefs(user):
+    """Per-user preferences row (theme + reader settings), created on demand."""
+    prefs, _ = Theme.objects.get_or_create(user=user)
+    return prefs
+
+
 def sopds_login(function=None, redirect_field_name=REDIRECT_FIELD_NAME, url=None):
     actual_decorator = user_passes_test(
         lambda u: (u.is_authenticated if config.SOPDS_AUTH else True),
@@ -310,6 +316,33 @@ def ThemeView(request):
     else:
         Theme.objects.create(user=request.user, theme_css="css/sopds-dark.css")
     return HttpResponseRedirect(request.META.get('HTTP_REFERER'))
+
+
+@vary_on_headers("HTTP_ACCEPT_LANGUAGE")
+@sopds_login(url='web:login')
+def SettingsView(request):
+    prefs = user_prefs(request.user)
+    if request.method == 'POST':
+        prefs.theme_css = 'css/sopds-dark.css' if request.POST.get('theme') == 'dark' else 'css/sopds.css'
+        prefs.reader_mode = (Theme.READER_CHAPTERS if request.POST.get('reader_mode') == Theme.READER_CHAPTERS
+                             else Theme.READER_WHOLE)
+        try:
+            fs = int(request.POST.get('font_size', 100))
+        except (TypeError, ValueError):
+            fs = 100
+        prefs.font_size = min(200, max(70, fs))
+        prefs.save()
+        return redirect(reverse('web:settings'))
+
+    args = {
+        'current': 'settings',
+        'breadcrumbs': [_('Settings')],
+        'prefs': prefs,
+        'is_dark': prefs.theme_css == 'css/sopds-dark.css',
+        'css_file': prefs.theme_css,
+    }
+    args.update(csrf(request))
+    return render(request, 'sopds_settings.html', args)
 
 
 @vary_on_headers("HTTP_ACCEPT_LANGUAGE")
@@ -689,10 +722,13 @@ def LogoutView(request):
 @vary_on_headers("HTTP_ACCEPT_LANGUAGE")
 @sopds_login(url='web:login')
 def BookReaderView(request, book_id):
+    prefs = user_prefs(request.user)
     args = {}
     args['current'] = 'reader'
     args['book_id'] = book_id
-    args['css_file'] = theme_css(request.user)
+    args['reader_mode'] = prefs.reader_mode
+    args['font_size'] = prefs.font_size
+    args['css_file'] = prefs.theme_css
     return render(request, 'BookReader.html', args)
 
 


### PR DESCRIPTION
Items 1–4 and 10 of the feature list: a user settings page and reader preferences.

## Changes
- **Settings page `/web/settings/`** (all authenticated users): theme (light/dark), reader mode (whole text / by chapters), reader font size (70–200%). Saved via POST on the per-user `Theme` model (migration `0014` adds `reader_mode`, `font_size`).
- **Top bar**: "Settings" now opens this page; the Django admin moved to a separate **Admin** button shown only to superusers; the standalone theme toggle is removed (theme lives in Settings now).
- **Reader**:
  - **Font size** from settings applied to the book text.
  - **Progress indicator** — a bottom progress bar + percentage.
  - **By-chapters mode** — splits the rendered book by its `TOC_` section anchors, shows one chapter at a time with ◀/▶ navigation and a chapter counter; falls back to whole-text if no chapters are found. The saved reading position works in both modes (restores the right chapter).

## Notes
- This is PR 1 of 4 for the requested batch. Next: (2) book status + rating, (3) health/readiness probes + raven→sentry-sdk, (4) full dependency upgrade to Django 5.2 LTS.
- Chapter splitting/progress is client-side; no backend rendering change.

## Verification
Static only in this environment (no runnable app/DB): `py_compile` of models/migration/views/urls; template tags balanced. Needs a live pass: open Settings, switch theme/mode/font; in the reader check progress bar, and by-chapters navigation + position restore.