### PR TITLE
Align test deps with production (Django 5.2) via constraints

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,14 +1,19 @@
 # Minimal dependency set to run the test suite on sqlite (see pytest.ini).
 # Used by CI and for fast local test runs. Deliberately excludes
-# production-only / slow-to-build / optional packages that the tests never
-# import (uwsgi, psycopg2-binary, redis, sentry-sdk, mcp, python-telegram-bot);
-# the suite runs on sqlite. Keep the shared runtime pins aligned with
-# requirements.txt.
-Django==4.2.30
-Pillow==10.4.0
-lxml==6.1.1
-django-picklefield==3.2
-six==1.16.0
+# production-only / slow-to-build / optional packages the tests never import
+# (uwsgi, psycopg2-binary, redis, sentry-sdk, mcp, python-telegram-bot,
+# apscheduler, ...); the suite runs on sqlite.
+#
+# Shared runtime packages are version-constrained by requirements.txt so this
+# test environment never drifts from production (e.g. the Django version always
+# matches). Only the test toolchain is pinned directly here.
+-c requirements.txt
+
+Django
+Pillow
+lxml
+django-picklefield
+six
 
 pytest==9.1.1
 pytest-django==4.12.0


### PR DESCRIPTION
## What & why

After **#14 (Django 5.2 LTS)** and **#15 (pytest safety net)** both landed on `master`, the test dependency set was left pointing at the old Django.

`requirements-test.txt` came from #15, which was branched off the pre-5.2 `master`, so it hard-pinned `Django==4.2.30`, `django-picklefield==3.2`, `Pillow==10.4.0`. Result: **CI ran the suite on Django 4.2 while production (`requirements.txt`) runs Django 5.2.16** — the safety net was validating the wrong version.

## Fix

Stop duplicating version pins. Constrain the shared runtime packages with `-c requirements.txt` and list them unversioned, so the test environment always tracks production automatically. Only the pytest toolchain stays pinned in this file.

## Verification (clean venv)
- Resolves `Django 5.2.16`, `django-picklefield 3.4.0`, `Pillow 11.3.0` — matching `requirements.txt`.
- Production-only / slow-to-build deps stay absent (uwsgi, psycopg2, redis, sentry, mcp, telegram, apscheduler).
- `62 passed` on Django 5.2.16.

No application code changes.
