### PR TITLE
Return 404 instead of 500 for missing genre/book (views + feeds)

### DIFF
--- a/opds_catalog/feeds.py
+++ b/opds_catalog/feeds.py
@@ -3,7 +3,7 @@ from django.utils.translation import gettext as _
 from django.utils.feedgenerator import Atom1Feed, Enclosure, rfc3339_date
 from django.contrib.syndication.views import Feed
 from django.urls import reverse
-from django.shortcuts import render
+from django.shortcuts import render, get_object_or_404
 from django.db.models import Count, Min
 from django.utils.html import strip_tags
 
@@ -1008,7 +1008,7 @@ class GenresFeed(AuthFeed):
         if section_id==0:
             dataset = Genre.objects.values('section').annotate(section_id=Min('id'), num_book=Count('book')).filter(num_book__gt=0).order_by('section')
         else:
-            section = Genre.objects.get(id=section_id).section
+            section = get_object_or_404(Genre, id=section_id).section
             dataset = Genre.objects.filter(section=section).annotate(num_book=Count('book')).filter(num_book__gt=0).values().order_by('subsection')       
         return dataset
 

--- a/opds_catalog/tests/test_feeds_404.py
+++ b/opds_catalog/tests/test_feeds_404.py
@@ -1,0 +1,33 @@
+"""OPDS feeds must return 404 (not 500) for a non-existent object id.
+
+GenresFeed looks up the Genre inside items(), which the Django syndication
+framework does NOT wrap, so an unknown id raised DoesNotExist (HTTP 500) until
+it was switched to get_object_or_404.
+
+The SearchBooksFeed "doubles" lookup lives in get_object(), which Feed.__call__
+already wraps in `except ObjectDoesNotExist -> Http404`, so it returns 404
+without any change here; that test is a behavioural guard against the lookup
+being moved out of get_object() later.
+"""
+import pytest
+
+MISSING_ID = 999999
+
+
+@pytest.fixture
+def logged_client(client, django_user_model):
+    user = django_user_model.objects.create_user(username="opds", password="pw")
+    client.force_login(user)
+    return client
+
+
+@pytest.mark.django_db
+def test_genres_feed_missing_section_returns_404(logged_client):
+    resp = logged_client.get(f"/opds/genres/{MISSING_ID}/")
+    assert resp.status_code == 404
+
+
+@pytest.mark.django_db
+def test_search_doubles_feed_missing_book_returns_404(logged_client):
+    resp = logged_client.get(f"/opds/search/books/d/{MISSING_ID}/")
+    assert resp.status_code == 404

--- a/sopds_web_backend/tests/test_missing_object_404.py
+++ b/sopds_web_backend/tests/test_missing_object_404.py
@@ -1,0 +1,32 @@
+"""Web views must return 404 (not 500) for a non-existent object id.
+
+GenresView and the "doubles" branch of SearchBooksView fetched Genre/Book by
+id with .get(), raising DoesNotExist (HTTP 500) for an unknown id. They now
+use get_object_or_404.
+"""
+import pytest
+
+MISSING_ID = 999999
+
+
+@pytest.fixture
+def logged_client(client, django_user_model):
+    user = django_user_model.objects.create_user(username="bob", password="pw")
+    client.force_login(user)
+    return client
+
+
+@pytest.mark.django_db
+def test_genres_view_missing_section_returns_404(logged_client):
+    from django.urls import reverse
+    resp = logged_client.get(reverse("web:genre"), {"section": MISSING_ID})
+    assert resp.status_code == 404
+
+
+@pytest.mark.django_db
+def test_search_doubles_missing_book_returns_404(logged_client):
+    from django.urls import reverse
+    resp = logged_client.get(
+        reverse("web:searchbooks"), {"searchtype": "d", "searchterms": MISSING_ID}
+    )
+    assert resp.status_code == 404

--- a/sopds_web_backend/views.py
+++ b/sopds_web_backend/views.py
@@ -1,6 +1,6 @@
 from random import randint
 
-from django.shortcuts import render, redirect
+from django.shortcuts import render, redirect, get_object_or_404
 from django.template.context_processors import csrf
 from django.core.cache import cache
 from django.db.models import Count, Min, Max, Prefetch
@@ -189,9 +189,8 @@ def SearchBooksView(request):
                 
         # Поиск дубликатов для книги            
         elif searchtype == 'd':
-            #try:
             book_id = int(searchterms)
-            mbook = Book.objects.get(id=book_id)
+            mbook = get_object_or_404(Book, id=book_id)
             books = Book.objects.filter(title=mbook.title, authors__in=mbook.authors.all()).exclude(id=book_id).distinct().order_by('-docdate')
             args['breadcrumbs'] = [_('Books'),_('Doubles for book'),mbook.title]
             args['searchobject'] = 'title'
@@ -606,7 +605,7 @@ def GenresView(request):
         items = Genre.objects.values('section').annotate(section_id=Min('id'), num_book=Count('book')).filter(num_book__gt=0).order_by('section')
         args['breadcrumbs'] =  [_('Genres'),_('Select')]
     else:
-        section = Genre.objects.get(id=section_id).section
+        section = get_object_or_404(Genre, id=section_id).section
         items = Genre.objects.filter(section=section).annotate(num_book=Count('book')).filter(num_book__gt=0).values().order_by('subsection')   
         args['breadcrumbs'] =  [_('Genres'),_('Select'),section]   
           


### PR DESCRIPTION
## What & why

Follow-up to #15 (which fixed the same class of bug in `dl.py`). Three more code paths fetched an object by id with `.get()` outside any exception handling, so an unknown id raised `DoesNotExist` → **HTTP 500** instead of 404:

- **`SearchBooksView`** — the `'doubles'` (`searchtype=d`) branch. Its `try:` had been commented out, leaving `Book.objects.get(id=...)` unguarded.
- **`GenresView`** — the section drill-down (`?section=<id>`).
- **`GenresFeed.items()`** — the OPDS section drill-down. `Feed.__call__` wraps only `get_object()` in `except ObjectDoesNotExist → Http404`, not `items()`, so this one really did 500.

All three now use `get_object_or_404`.

## Deliberately left unchanged
- The already-guarded lookups: the `try/except` branches in `SearchBooksView` (`'a'`/`'s'`/`'g'`) and `CatalogsFeed.get_object` — they degrade to empty results by design.
- `SearchBooksFeed`'s `'doubles'` lookup lives in `get_object()`, which the syndication framework already maps to 404 — no code change needed.

## Tests
`sopds_web_backend/tests/test_missing_object_404.py` and `opds_catalog/tests/test_feeds_404.py` assert 404 for all four URLs (web genre, web doubles, OPDS genre, OPDS doubles). Verified the three real fixes fail (500) without the change; the OPDS-doubles test is documented as a framework-provided regression guard.

## Test result
`66 passed` on Django 5.2.16 / Python 3.12.
