### PR TITLE
Silence memcached CacheKeyWarning in the SQL-injection test

### DIFF
--- a/opds_catalog/tests/test_alphabet_menu_sql.py
+++ b/opds_catalog/tests/test_alphabet_menu_sql.py
@@ -35,6 +35,12 @@ def test_alphabet_menu_counts_normal_prefix():
     assert counts == {"AL": 1, "AN": 1}
 
 
+# The payload is intentionally used as (part of) a cache key, which Django's
+# cache layer flags as memcached-incompatible. That warning is noise here (the
+# project uses locmem/redis, not memcached), so silence it for this test only.
+@pytest.mark.filterwarnings(
+    "ignore::django.core.cache.backends.base.CacheKeyWarning"
+)
 @pytest.mark.django_db
 def test_alphabet_menu_rejects_sql_injection():
     _make_book("Alpha")


### PR DESCRIPTION
## What & why

The SQL-injection regression test (added in #15) feeds a `'; DROP TABLE ... --` payload through `alphabet_menu()`, which becomes part of a cache key. Django's cache layer emits a `CacheKeyWarning` (the key would be invalid for memcached). The project uses locmem/redis, not memcached, so it's pure test noise.

Silence it for that single test with a `filterwarnings` marker — no global suppression, so real cache-key issues elsewhere still surface.

## Test result
`3 passed`, no warnings.
