### PR TITLE
Return 404 instead of 500 for non-numeric search/genre ids

### DIFF
--- a/opds_catalog/feeds.py
+++ b/opds_catalog/feeds.py
@@ -4,6 +4,7 @@ from django.utils.feedgenerator import Atom1Feed, Enclosure, rfc3339_date
 from django.contrib.syndication.views import Feed
 from django.urls import reverse
 from django.shortcuts import render, get_object_or_404
+from django.http import Http404
 from django.db.models import Count, Min
 from django.utils.html import strip_tags
 
@@ -453,7 +454,10 @@ class SearchBooksFeed(AuthFeed):
                 books=Book.objects.filter(id=0)  
         # Поиск дубликатов для книги            
         elif searchtype == 'd':
-            book_id = int(searchterms)
+            try:
+                book_id = int(searchterms)
+            except (TypeError, ValueError):
+                raise Http404
             mbook = Book.objects.get(id=book_id)
             books = Book.objects.filter(title__iexact=mbook.title, authors__in=mbook.authors.all()).exclude(id=book_id).order_by('search_title','-docdate')
                     

--- a/sopds_web_backend/tests/test_malformed_input_404.py
+++ b/sopds_web_backend/tests/test_malformed_input_404.py
@@ -1,0 +1,37 @@
+"""Non-numeric ids in search/genre params must return 404, not 500.
+
+Several views cast a user-supplied value to int() with no guard, so a
+non-numeric value raised ValueError -> HTTP 500. Covers:
+ - web GenresView (?section=abc)
+ - web SearchBooksView doubles (searchtype=d, non-numeric searchterms)
+ - OPDS SearchBooksFeed doubles (/opds/search/books/d/<non-numeric>/)
+"""
+import pytest
+from django.urls import reverse
+
+
+@pytest.fixture
+def logged_client(client, django_user_model):
+    user = django_user_model.objects.create_user(username="mel", password="pw")
+    client.force_login(user)
+    return client
+
+
+@pytest.mark.django_db
+def test_genres_view_non_numeric_section_returns_404(logged_client):
+    resp = logged_client.get(reverse("web:genre"), {"section": "abc"})
+    assert resp.status_code == 404
+
+
+@pytest.mark.django_db
+def test_search_doubles_non_numeric_returns_404(logged_client):
+    resp = logged_client.get(
+        reverse("web:searchbooks"), {"searchtype": "d", "searchterms": "abc"}
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.django_db
+def test_opds_search_doubles_non_numeric_returns_404(logged_client):
+    resp = logged_client.get("/opds/search/books/d/abc/")
+    assert resp.status_code == 404

--- a/sopds_web_backend/views.py
+++ b/sopds_web_backend/views.py
@@ -24,7 +24,7 @@ from opds_catalog.opds_paginator import Paginator as OPDS_Paginator
 
 
 from sopds_web_backend.settings import HALF_PAGES_LINKS
-from django.http import HttpResponse, JsonResponse
+from django.http import HttpResponse, JsonResponse, Http404
 
 
 def theme_css(user):
@@ -189,7 +189,10 @@ def SearchBooksView(request):
                 
         # Поиск дубликатов для книги            
         elif searchtype == 'd':
-            book_id = int(searchterms)
+            try:
+                book_id = int(searchterms)
+            except (TypeError, ValueError):
+                raise Http404
             mbook = get_object_or_404(Book, id=book_id)
             books = Book.objects.filter(title=mbook.title, authors__in=mbook.authors.all()).exclude(id=book_id).distinct().order_by('-docdate')
             args['breadcrumbs'] = [_('Books'),_('Doubles for book'),mbook.title]
@@ -597,7 +600,10 @@ def GenresView(request):
     args = {}
 
     if request.GET:
-        section_id = int(request.GET.get('section', '0'))  
+        try:
+            section_id = int(request.GET.get('section', '0'))
+        except (TypeError, ValueError):
+            raise Http404
     else:
         section_id = 0
         


### PR DESCRIPTION
## What & why

Follow-up to #17 (missing-id → 404). Three paths cast a user-supplied value to `int()` with no guard, so a **non-numeric** value raised `ValueError` → **HTTP 500**:

- **`SearchBooksView`** doubles (`?searchtype=d&searchterms=abc`)
- **`GenresView`** (`?section=abc`)
- **`SearchBooksFeed`** doubles get_object (`/opds/search/books/d/abc/`) — the syndication framework maps `ObjectDoesNotExist`→404 but **not** `ValueError`

Each `int()` is now guarded and raises `Http404` on a bad value.

## Tests
`sopds_web_backend/tests/test_malformed_input_404.py` — the three URLs return 404. Verified they 500 without the fix.

## Test result
`74 passed` on Django 5.2.16 / Python 3.12.

## Note
`page` params (`?page=abc`) across the list views are a separate, broader `int()`-hardening class and were left out to keep this focused.
