### PR TITLE
Add tooling config (ruff/mypy) and project docs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,3 +27,20 @@ jobs:
           pytest
           --cov=opds_catalog --cov=sopds_web_backend --cov=book_tools
           --cov-report=term-missing
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - run: pip install ruff
+
+      # Non-blocking for now: reports ruff findings as PR annotations without
+      # failing the pipeline, so the legacy code can be cleaned up gradually.
+      - name: ruff
+        run: ruff check --output-format=github .
+        continue-on-error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to this project are documented here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Added
+- htmx live-search suggestions in the header search box (title/author/series),
+  as progressive enhancement.
+- pytest / pytest-django test suite with coverage; GitHub Actions CI running
+  the suite on Python 3.12, plus a non-blocking `ruff` lint pass.
+- Tooling config in `pyproject.toml` (ruff, mypy); `CONTRIBUTING.md`.
+
+### Changed
+- Upgraded to Django 5.2 LTS (Python 3.13 / PostgreSQL supported).
+- Test dependencies are constrained by `requirements.txt` (`requirements-test.txt`
+  uses `-c`), so the test environment never drifts from production.
+
+### Fixed
+- **Security:** open redirect in `LoginView` (`?next=` is now validated with
+  `url_has_allowed_host_and_scheme`).
+- Hardened the book-conversion route: `convert_type` restricted to `epub|mobi`
+  and `ConvertFB2` raises `Http404` for anything else (was a 500).
+- Return **404 instead of 500** for missing or non-numeric ids across the
+  download/convert/read/cover views, the genre and "doubles" search views, and
+  the corresponding OPDS feeds.
+
+### Security
+- Regression test locking in that `alphabet_menu()` passes user input as bound
+  parameters (no SQL injection) and escapes LIKE wildcards.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing
+
+## Development setup
+
+```bash
+python -m venv .venv && . .venv/bin/activate
+pip install -r requirements-test.txt   # fast, test-only deps (sqlite)
+# or: pip install -r requirements-dev.txt   # full runtime + test toolchain
+```
+
+## Running the tests
+
+The suite runs on an in-memory sqlite via `sopds/settings_test.py`:
+
+```bash
+pytest
+pytest --cov=opds_catalog --cov=sopds_web_backend --cov=book_tools --cov-report=term-missing
+```
+
+CI runs the same suite on Python 3.12 for every pull request, plus a
+non-blocking `ruff` lint pass.
+
+## Linting / type-checking
+
+Config lives in `pyproject.toml` (tool config only; deps stay in
+`requirements*.txt`).
+
+```bash
+ruff check .          # syntax errors + pyflakes (E9, F)
+mypy opds_catalog sopds_web_backend book_tools   # lenient; tighten over time
+```
+
+`ruff` is currently advisory (the pipeline does not fail on findings) so the
+legacy code can be cleaned up incrementally. Please don't add new findings.
+
+## Conventions
+
+- **Branch** from `master`; open a pull request against `master`.
+- **Sign off** every commit (Developer Certificate of Origin):
+  `git commit -s`.
+- Keep commits focused; write a clear subject and a body explaining *why*.
+- Add or update tests for behavioural changes. A missing-object lookup should
+  return **404, not 500** (see the `get_object_or_404` usages and the
+  `test_*_404.py` tests for the pattern).
+- Note user-facing changes in `CHANGELOG.md` under **Unreleased**.
+
+## Deployment
+
+Production is deployed from the separate `sopds-k8s` repository (werf + GitLab
+CI). That repo pins a specific `duckhawk/sopds` commit; after merging to
+`master`, bump the pin there.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+# Tool configuration only. Packaging/runtime deps stay in requirements*.txt.
+
+[tool.ruff]
+target-version = "py312"
+line-length = 120
+# Vendored / generated code kept verbatim — not ours to lint.
+extend-exclude = ["constance", "convert", "static", "*/migrations/*"]
+
+[tool.ruff.lint]
+# Conservative baseline: syntax errors (E9) + pyflakes (F) catch real problems
+# (unused imports, undefined names) without style noise. Style/isort/bugbear
+# rules can be enabled incrementally as the legacy code is cleaned up.
+select = ["E9", "F"]
+
+[tool.ruff.lint.per-file-ignores]
+# Re-exports in package inits.
+"__init__.py" = ["F401"]
+
+[tool.mypy]
+python_version = "3.12"
+# Lenient by design: large untyped legacy codebase. Tighten module by module.
+ignore_missing_imports = true
+exclude = "(^|/)(constance|convert|static)/|/migrations/"


### PR DESCRIPTION
## What & why

Adds developer-tooling config and project docs (from the fork review). **Additive, no production code changes.**

- **`pyproject.toml`** — `ruff` (`E9`,`F` — syntax errors + pyflakes) and `mypy` (lenient) config. Tool config only; packaging/runtime deps stay in `requirements*.txt`. Vendored/generated code (`constance`, `convert`, `static`, migrations) excluded.
- **`CONTRIBUTING.md`** — setup, running tests (`requirements-test.txt` + pytest), lint/typecheck, branch/commit conventions (DCO `-s`), and the deployment note (werf pin in `sopds-k8s`).
- **`CHANGELOG.md`** — Keep a Changelog with an *Unreleased* section summarising the recent work.
- **CI** — a **non-blocking** `ruff` job (`continue-on-error`) that annotates PRs without failing the pipeline.

## Notes
- `ruff check .` currently reports ~44 findings in legacy code (mostly unused imports/vars). Left as-is and surfaced non-blocking, to be cleaned up incrementally rather than in one risky sweep — so this PR changes **no** application code.
- `pytest` is unaffected (still driven by `pytest.ini` / `settings_test`); `71 passed` locally.
