### PR TITLE
Fix telebot crash: bump APScheduler to 3.10.4, disable JobQueue

### DIFF
--- a/opds_catalog/management/commands/sopds_telebot.py
+++ b/opds_catalog/management/commands/sopds_telebot.py
@@ -347,7 +347,9 @@ class Command(BaseCommand):
         quit_command = 'CTRL-BREAK' if sys.platform == 'win32' else 'CONTROL-C'
         self.stdout.write("Quit the sopds_telebot with %s.\n" % quit_command)
         try:
-            application = Application.builder().token(config.SOPDS_TELEBOT_API_TOKEN).build()
+            # The bot does not use PTB's JobQueue; disabling it avoids spinning
+            # up an unused APScheduler event loop.
+            application = Application.builder().token(config.SOPDS_TELEBOT_API_TOKEN).job_queue(None).build()
             application.add_handler(CommandHandler('start', self.startCommand))
             # /downloadNNN is matched before free-text book queries.
             application.add_handler(MessageHandler(filters.Regex(r'^/download\d+$'), self.downloadBooks))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,11 @@
 Django==5.2.16
 Pillow==11.3.0
-# APScheduler powers the sopds_scanner scheduled scans. Pinned to 3.6.x, which
-# needs tzlocal<3 and imports pkg_resources (see the setuptools note below).
-apscheduler==3.6.3
-# apscheduler 3.6.3 imports pkg_resources at load; Python 3.12 no longer
+# APScheduler: used by sopds_scanner (scheduled scans) and required by
+# python-telegram-bot 21's JobQueue (needs >=3.10.4). 3.10.x accepts stdlib/
+# zoneinfo timezones (3.6.x only accepted pytz, which crashed the bot on the
+# container's local timezone) and pulls pytz/tzlocal itself. Keeps tzlocal<3.
+apscheduler==3.10.4
+# apscheduler still imports pkg_resources at load; Python 3.12 no longer
 # bundles setuptools, and setuptools>=81 dropped pkg_resources.
 setuptools==75.8.0
 tzlocal==2.1


### PR DESCRIPTION
## Fixes the live telebot crash

```
TypeError: Only timezones from the pytz library are supported
```

### Root cause
`python-telegram-bot` 21's `ApplicationBuilder.__init__` **eagerly** creates a default `JobQueue` (an APScheduler `AsyncIOScheduler`). So `Application.builder()` crashed before `.token()`/`.build()`. The image pins **APScheduler 3.6.3** (for `sopds_scanner`), and 3.6.x only accepts `pytz` timezones — it rejects the container's stdlib/`zoneinfo` local timezone (`Asia/Yekaterinburg`). Chaining `.job_queue(None)` couldn't help because the crash is in the builder constructor.

### Fix
- **APScheduler 3.6.3 → 3.10.4** — the version PTB 21 requires (`>=3.10.4`). 3.9+ accepts stdlib/`zoneinfo` timezones and pulls `pytz` itself. Verified the scanner's `BlockingScheduler` + `add_job('cron', …)` / `reschedule_job(trigger='cron', …)` / `add_job(id=…)` calls all still work on 3.10.4.
- **`job_queue(None)`** on the builder — the bot never schedules jobs, so no APScheduler loop needs to run for it.

### Validated
- `Application.builder().token(…).job_queue(None).build()` succeeds under Django with `TZ=Asia/Yekaterinburg` on APScheduler 3.10.4 (previously crashed) ✅
- Bot module imports; scanner APScheduler calls work ✅
- Full test suite: `90 passed` ✅
- NOT validated: live Telegram flows (needs a token) — but this unblocks the crash that prevented the bot from starting at all.
