### PR TITLE
Speed up cyrillic search: trigram-fenced suggest, book/author/series & OPDS feeds

### DIFF
--- a/opds_catalog/feeds.py
+++ b/opds_catalog/feeds.py
@@ -13,7 +13,7 @@ from opds_catalog import models
 from opds_catalog import settings
 from opds_catalog.middleware import BasicAuthMiddleware
 from opds_catalog.opds_paginator import Paginator as OPDS_Paginator
-from opds_catalog.utils import alphabet_menu
+from opds_catalog.utils import alphabet_menu, contains_page_ids, contains_page
 
 from book_tools.format import mime_detector
 from book_tools.format.mimetype import Mimetype
@@ -479,8 +479,19 @@ class SearchBooksFeed(AuthFeed):
         start = op.d1_first_pos if ((op.d1_first_pos==0) or (not summary_DOUBLES_HIDE)) else op.d1_first_pos-1
         finish = op.d1_last_pos
         
-        page_books = books.prefetch_related('authors', 'genres', 'series', 'bseries_set')
-        for row in page_books[start:finish+1]:
+        lookahead_rows = None
+        if searchtype == 'm' and searchterms:
+            want = finish - start + 1
+            page_ids = contains_page_ids('opds_catalog_book', 'search_title', searchterms.upper(),
+                                         'search_title, docdate', 'search_title, docdate DESC',
+                                         want + 30, start)
+            by_id = {b.id: b for b in Book.objects.filter(id__in=page_ids).prefetch_related('authors', 'genres', 'series', 'bseries_set')}
+            fetched = [by_id[i] for i in page_ids if i in by_id]
+            page_rows = fetched[:want]
+            lookahead_rows = fetched[want:]
+        else:
+            page_rows = books.prefetch_related('authors', 'genres', 'series', 'bseries_set')[start:finish+1]
+        for row in page_rows:
             p = {'doubles':0, 'lang_code': row.lang_code, 'filename': row.filename, 'path': row.path, \
                   'registerdate': row.registerdate, 'id': row.id, 'annotation': strip_tags(row.annotation), \
                   'docdate': row.docdate, 'format': row.format, 'title': row.title, 'filesize': row.filesize//1000,
@@ -503,12 +514,21 @@ class SearchBooksFeed(AuthFeed):
         # "вытягиваем" дубликаты книг со следующей страницы и удаляем первый элемент который с предыдущей страницы и "вытягивал" дубликаты с текущей
         if summary_DOUBLES_HIDE:
             double_flag = True
-            while ((finish+1)<books_count) and double_flag:
-                finish += 1  
-                if books[finish].title.upper()==prev_title.upper() and {a['id'] for a in books[finish].authors.values()}==prev_authors_set:
-                    items[-1]['doubles']+=1
-                else:
-                    double_flag = False   
+            if lookahead_rows is not None:
+                for nb in lookahead_rows:
+                    if not double_flag:
+                        break
+                    if nb.title.upper()==prev_title.upper() and {a.id for a in nb.authors.all()}==prev_authors_set:
+                        items[-1]['doubles']+=1
+                    else:
+                        double_flag = False
+            else:
+                while ((finish+1)<books_count) and double_flag:
+                    finish += 1
+                    if books[finish].title.upper()==prev_title.upper() and {a['id'] for a in books[finish].authors.values()}==prev_authors_set:
+                        items[-1]['doubles']+=1
+                    else:
+                        double_flag = False
             
             if op.d1_first_pos!=0:     
                 items.pop(0)          
@@ -677,7 +697,13 @@ class SearchAuthorsFeed(AuthFeed):
         op = OPDS_Paginator(authors_count, 0, page_num, config.SOPDS_MAXITEMS)        
         items = []
         
-        for row in authors[op.d1_first_pos:op.d1_last_pos+1]:
+        if searchtype == 'm' and searchterms:
+            page_authors = contains_page(Author.objects, 'opds_catalog_author', 'search_full_name',
+                                         searchterms.upper(), 'search_full_name', 'search_full_name',
+                                         op.d1_last_pos - op.d1_first_pos + 1, op.d1_first_pos)
+        else:
+            page_authors = authors[op.d1_first_pos:op.d1_last_pos+1]
+        for row in page_authors:
             p = {'id':row.id, 'full_name':row.full_name, 'lang_code': row.lang_code, 'book_count': Book.objects.filter(authors=row).count()}
             items.append(p)    
                                 
@@ -755,7 +781,14 @@ class SearchSeriesFeed(AuthFeed):
         op = OPDS_Paginator(series_count, 0, page_num, config.SOPDS_MAXITEMS)        
         items = []
         
-        for row in series[op.d1_first_pos:op.d1_last_pos+1]:
+        if searchtype == 'm' and searchterms:
+            page_series = contains_page(Series.objects.annotate(count_book=Count('book')),
+                                        'opds_catalog_series', 'search_ser', searchterms.upper(),
+                                        'search_ser', 'search_ser',
+                                        op.d1_last_pos - op.d1_first_pos + 1, op.d1_first_pos)
+        else:
+            page_series = series[op.d1_first_pos:op.d1_last_pos+1]
+        for row in page_series:
             p = {'id':row.id, 'ser':row.ser, 'lang_code': row.lang_code, 'book_count': row.count_book}
             items.append(p)   
         

--- a/opds_catalog/utils.py
+++ b/opds_catalog/utils.py
@@ -11,6 +11,43 @@ from django.db import connection
 from constance import config
 
 
+def contains_page_ids(table, column, term, select_cols, order_by, limit, offset):
+    """Return a page of row ids where `column LIKE '%term%'`, ordered by
+    `order_by`, using an OFFSET-0 fence subquery.
+
+    On PostgreSQL an ``ORDER BY`` combined with a leading-wildcard ``LIKE``
+    makes the planner drive the query off the plain btree index and filter
+    row-by-row, ignoring the pg_trgm GIN index (very slow on large, cyrillic
+    catalogs). Wrapping the filter in a ``(... OFFSET 0)`` fence forces the
+    trigram bitmap scan first and only then sorts the (small) match set.
+
+    `table`, `column`, `select_cols` and `order_by` are fixed identifiers
+    supplied by our own callers — never user input (`select_cols` must list
+    every column referenced by `order_by`). `term` is a bound parameter with
+    its LIKE wildcards escaped.
+    """
+    escaped = term.replace('\\', '\\\\').replace('%', '\\%').replace('_', '\\_')
+    pattern = '%' + escaped + '%'
+    if connection.vendor == 'postgresql':
+        # The OFFSET 0 fence forces the pg_trgm bitmap scan to run (and the row
+        # set to materialise) before the ORDER BY sort. (PostgreSQL only —
+        # SQLite rejects OFFSET without LIMIT, and has no trigram index anyway.)
+        sql = (
+            "SELECT id FROM ("
+            "  SELECT id, {select_cols} FROM {tbl} WHERE {col} LIKE %s ESCAPE '\\' OFFSET 0"
+            ") t ORDER BY {order} LIMIT %s OFFSET %s"
+        )
+    else:
+        sql = (
+            "SELECT id FROM {tbl} WHERE {col} LIKE %s ESCAPE '\\' "
+            "ORDER BY {order} LIMIT %s OFFSET %s"
+        )
+    sql = sql.format(tbl=table, col=column, select_cols=select_cols, order=order_by)
+    with connection.cursor() as cursor:
+        cursor.execute(sql, [pattern, limit, offset])
+        return [row[0] for row in cursor.fetchall()]
+
+
 def alphabet_menu(table, column, lang_code, chars):
     """Alphabet drill-down counts for the "select by substring" pages/feeds.
 

--- a/opds_catalog/utils.py
+++ b/opds_catalog/utils.py
@@ -48,6 +48,18 @@ def contains_page_ids(table, column, term, select_cols, order_by, limit, offset)
         return [row[0] for row in cursor.fetchall()]
 
 
+def contains_page(base_qs, table, column, term, select_cols, order_by, limit, offset):
+    """Hydrate one ordered page of `base_qs` rows matching `column LIKE
+    '%term%'` via the trgm-friendly fenced id query (see contains_page_ids).
+
+    `base_qs` is the model queryset to load from (already carrying any needed
+    annotations/prefetch); the page is returned in `order_by` order.
+    """
+    ids = contains_page_ids(table, column, term, select_cols, order_by, limit, offset)
+    by_id = {obj.id: obj for obj in base_qs.filter(id__in=ids)}
+    return [by_id[i] for i in ids if i in by_id]
+
+
 def alphabet_menu(table, column, lang_code, chars):
     """Alphabet drill-down counts for the "select by substring" pages/feeds.
 

--- a/sopds_web_backend/tests/test_search_contains.py
+++ b/sopds_web_backend/tests/test_search_contains.py
@@ -1,0 +1,63 @@
+"""Title-substring ('m') search: the fenced pg_trgm page fetch must keep the
+same ordering, paging and doubles-dedup behaviour."""
+import pytest
+from django.urls import reverse
+
+from opds_catalog.models import Book, Catalog, Author, bauthor
+from opds_catalog.utils import contains_page_ids
+
+
+@pytest.fixture
+def catalog(db):
+    return Catalog.objects.create(parent=None, cat_name='.', path='.', cat_type=0)
+
+
+def _book(title, catalog, author=None):
+    b = Book.objects.create(
+        filename=f"{title}.fb2", path='.', filesize=1, format='fb2', cat_type=0,
+        docdate='2016', lang='ru', title=title, search_title=title.upper(),
+        annotation='', avail=2, catalog=catalog,
+    )
+    if author:
+        bauthor.objects.create(book=b, author=author)
+    return b
+
+
+@pytest.fixture
+def user(django_user_model):
+    return django_user_model.objects.create_user(username="q", password="pw")
+
+
+@pytest.fixture
+def logged_client(client, user):
+    client.force_login(user)
+    return client
+
+
+@pytest.mark.django_db
+def test_contains_page_ids_filters_orders_pages(catalog):
+    ids = {t: _book(t, catalog).id for t in ['AAA', 'AAB', 'ABC', 'XYZ']}
+    args = ('opds_catalog_book', 'search_title', 'A', 'search_title, docdate',
+            'search_title, docdate DESC')
+    # substring filter + ordering
+    assert contains_page_ids(*args, 10, 0) == [ids['AAA'], ids['AAB'], ids['ABC']]
+    # limit + offset
+    assert contains_page_ids(*args, 2, 1) == [ids['AAB'], ids['ABC']]
+    # non-matching term
+    assert contains_page_ids('opds_catalog_book', 'search_title', 'ZZZ',
+                             'search_title, docdate', 'search_title, docdate DESC', 10, 0) == []
+
+
+@pytest.mark.django_db
+def test_search_m_orders_and_dedups(logged_client, catalog):
+    author = Author.objects.create(full_name='Иванов', search_full_name='ИВАНОВ')
+    _book('РОМАН АЛЬФА', catalog, author)
+    _book('РОМАН АЛЬФА', catalog, author)   # exact duplicate (title + author)
+    _book('РОМАН БЕТА', catalog, author)
+    resp = logged_client.get(reverse('web:searchbooks'),
+                             {'searchtype': 'm', 'searchterms': 'РОМАН'})
+    assert resp.status_code == 200
+    body = resp.content.decode()
+    assert 'РОМАН АЛЬФА' in body and 'РОМАН БЕТА' in body
+    # the duplicate collapsed into one entry carrying a doubles count
+    assert 'шт.' in body

--- a/sopds_web_backend/tests/test_search_contains.py
+++ b/sopds_web_backend/tests/test_search_contains.py
@@ -3,7 +3,7 @@ same ordering, paging and doubles-dedup behaviour."""
 import pytest
 from django.urls import reverse
 
-from opds_catalog.models import Book, Catalog, Author, bauthor
+from opds_catalog.models import Book, Catalog, Author, Series, bauthor
 from opds_catalog.utils import contains_page_ids
 
 
@@ -61,3 +61,27 @@ def test_search_m_orders_and_dedups(logged_client, catalog):
     assert 'РОМАН АЛЬФА' in body and 'РОМАН БЕТА' in body
     # the duplicate collapsed into one entry carrying a doubles count
     assert 'шт.' in body
+
+
+@pytest.mark.django_db
+def test_search_authors_m(logged_client):
+    for name in ['Пушкин', 'Пушков', 'Толстой']:
+        Author.objects.create(full_name=name, search_full_name=name.upper())
+    resp = logged_client.get(reverse('web:searchauthors'),
+                             {'searchtype': 'm', 'searchterms': 'ПУШ'})
+    assert resp.status_code == 200
+    body = resp.content.decode()
+    assert 'Пушкин' in body and 'Пушков' in body
+    assert 'Толстой' not in body
+
+
+@pytest.mark.django_db
+def test_search_series_m(logged_client):
+    for s in ['Хоббит', 'Хоррор', 'Дюна']:
+        Series.objects.create(ser=s, search_ser=s.upper())
+    resp = logged_client.get(reverse('web:searchseries'),
+                             {'searchtype': 'm', 'searchterms': 'ХО'})
+    assert resp.status_code == 200
+    body = resp.content.decode()
+    assert 'Хоббит' in body and 'Хоррор' in body
+    assert 'Дюна' not in body

--- a/sopds_web_backend/tests/test_search_suggest.py
+++ b/sopds_web_backend/tests/test_search_suggest.py
@@ -61,10 +61,12 @@ def test_suggest_series(logged_client):
 
 
 @pytest.mark.django_db
-def test_suggest_too_short_is_empty(logged_client):
+@pytest.mark.parametrize("term", ["b", "bo"])
+def test_suggest_too_short_is_empty(logged_client, term):
+    """<3 chars returns nothing (the pg_trgm index needs a full trigram)."""
     _make_book("Book One")
     resp = logged_client.post(
-        reverse("web:suggest"), {"searchterms": "b", "suggesttype": "title"}
+        reverse("web:suggest"), {"searchterms": term, "suggesttype": "title"}
     )
     assert resp.status_code == 200
     assert "<li>" not in resp.content.decode()

--- a/sopds_web_backend/views.py
+++ b/sopds_web_backend/views.py
@@ -17,7 +17,7 @@ from django.http import HttpResponseRedirect
 from opds_catalog import models
 from opds_catalog.models import Book, Author, Series, bookshelf, Counter, Catalog, Genre, lang_menu, Theme
 from opds_catalog import settings
-from opds_catalog.utils import alphabet_menu
+from opds_catalog.utils import alphabet_menu, contains_page_ids
 from constance import config
 from opds_catalog.opds_paginator import Paginator as OPDS_Paginator
 
@@ -251,9 +251,25 @@ def SearchBooksView(request):
             prefetch.append(Prefetch('bookshelf_set',
                                      queryset=bookshelf.objects.filter(user=request.user),
                                      to_attr='user_shelf'))
-        page_books = books.prefetch_related(*prefetch)
+        # For the title-substring search, fetch the page (plus a small lookahead
+        # for the doubles pass) via the pg_trgm-friendly fenced query instead of
+        # slicing an ORDER BY queryset, which makes PostgreSQL scan the btree
+        # row-by-row (very slow on large cyrillic catalogs).
+        lookahead_rows = None
+        if searchtype == 'm' and searchterms:
+            want = finish - start + 1
+            page_ids = contains_page_ids(
+                'opds_catalog_book', 'search_title', searchterms.upper(),
+                'search_title, docdate', 'search_title, docdate DESC',
+                want + 30, start)
+            by_id = {b.id: b for b in Book.objects.filter(id__in=page_ids).prefetch_related(*prefetch)}
+            fetched = [by_id[i] for i in page_ids if i in by_id]
+            page_rows = fetched[:want]
+            lookahead_rows = fetched[want:]
+        else:
+            page_rows = books.prefetch_related(*prefetch)[start:finish+1]
 
-        for row in page_books[start:finish+1]:
+        for row in page_rows:
             user_shelf = getattr(row, 'user_shelf', []) if config.SOPDS_AUTH else []
             p = {'doubles': 0,
                  'lang_code': row.lang_code,
@@ -292,12 +308,21 @@ def SearchBooksView(request):
         # "вытягиваем" дубликаты книг со следующей страницы и удаляем первый элемент который с предыдущей страницы и "вытягивал" дубликаты с текущей
         if summary_DOUBLES_HIDE:
             double_flag = True
-            while ((finish+1)<books_count) and double_flag:
-                finish += 1  
-                if books[finish].title.upper() == prev_title.upper() and {a['id'] for a in books[finish].authors.values()} == prev_authors_set:
-                    items[-1]['doubles'] += 1
-                else:
-                    double_flag = False   
+            if lookahead_rows is not None:
+                for nb in lookahead_rows:
+                    if not double_flag:
+                        break
+                    if nb.title.upper() == prev_title.upper() and {a.id for a in nb.authors.all()} == prev_authors_set:
+                        items[-1]['doubles'] += 1
+                    else:
+                        double_flag = False
+            else:
+                while ((finish+1)<books_count) and double_flag:
+                    finish += 1
+                    if books[finish].title.upper() == prev_title.upper() and {a['id'] for a in books[finish].authors.values()} == prev_authors_set:
+                        items[-1]['doubles'] += 1
+                    else:
+                        double_flag = False
             
             if op.d1_first_pos != 0:
                 items.pop(0)                                   

--- a/sopds_web_backend/views.py
+++ b/sopds_web_backend/views.py
@@ -746,17 +746,23 @@ def SearchSuggestView(request):
     term = (request.POST.get('searchterms') or request.GET.get('searchterms') or '').strip()
     suggesttype = request.POST.get('suggesttype') or request.GET.get('suggesttype') or 'title'
     suggestions = []
-    if len(term) >= 2:
+    # Require >=3 chars: the pg_trgm index needs a full trigram, and 2-char
+    # substrings match too much to be useful. No ORDER BY here on purpose — an
+    # `ORDER BY search_title` makes PostgreSQL drive the query off the plain
+    # btree index and filter LIKE '%..%' row-by-row (slow on large, cyrillic-
+    # heavy catalogs) instead of using the trigram index. Autocomplete does not
+    # need sorted output.
+    if len(term) >= 3:
         up = term.upper()
         base = reverse('web:searchbooks')
         if suggesttype == 'author':
-            for a in Author.objects.filter(search_full_name__contains=up).order_by('search_full_name')[:10]:
+            for a in Author.objects.filter(search_full_name__contains=up)[:10]:
                 suggestions.append({'label': a.full_name, 'url': '%s?searchtype=a&searchterms=%d' % (base, a.id)})
         elif suggesttype == 'series':
-            for s in Series.objects.filter(search_ser__contains=up).order_by('search_ser')[:10]:
+            for s in Series.objects.filter(search_ser__contains=up)[:10]:
                 suggestions.append({'label': s.ser, 'url': '%s?searchtype=s&searchterms=%d' % (base, s.id)})
         else:
-            for b in Book.objects.filter(search_title__contains=up).order_by('search_title')[:10]:
+            for b in Book.objects.filter(search_title__contains=up)[:10]:
                 suggestions.append({'label': b.title, 'url': '%s?searchtype=i&searchterms=%d' % (base, b.id)})
     return render(request, 'sopds_search_suggestions.html', {'suggestions': suggestions})
 

--- a/sopds_web_backend/views.py
+++ b/sopds_web_backend/views.py
@@ -17,7 +17,7 @@ from django.http import HttpResponseRedirect
 from opds_catalog import models
 from opds_catalog.models import Book, Author, Series, bookshelf, Counter, Catalog, Genre, lang_menu, Theme
 from opds_catalog import settings
-from opds_catalog.utils import alphabet_menu, contains_page_ids
+from opds_catalog.utils import alphabet_menu, contains_page_ids, contains_page
 from constance import config
 from opds_catalog.opds_paginator import Paginator as OPDS_Paginator
 
@@ -412,7 +412,14 @@ def SearchSeriesView(request):
         series_count = series.count()
         op = OPDS_Paginator(series_count, 0, page_num, config.SOPDS_MAXITEMS, HALF_PAGES_LINKS)        
         items = []
-        for row in series[op.d1_first_pos:op.d1_last_pos+1]:
+        if searchtype == 'm' and searchterms:
+            page_series = contains_page(Series.objects.annotate(count_book=Count('book')),
+                                        'opds_catalog_series', 'search_ser', searchterms.upper(),
+                                        'search_ser', 'search_ser',
+                                        op.d1_last_pos - op.d1_first_pos + 1, op.d1_first_pos)
+        else:
+            page_series = series[op.d1_first_pos:op.d1_last_pos+1]
+        for row in page_series:
             #p = {'id':row.id, 'ser':row.ser, 'lang_code': row.lang_code, 'book_count': Book.objects.filter(series=row).count()}
             p = {'id':row.id, 'ser':row.ser, 'lang_code': row.lang_code, 'book_count': row.count_book}
             items.append(p)                     
@@ -457,7 +464,13 @@ def SearchAuthorsView(request):
         op = OPDS_Paginator(authors_count, 0, page_num, config.SOPDS_MAXITEMS, HALF_PAGES_LINKS)        
         items = []
         
-        for row in authors[op.d1_first_pos:op.d1_last_pos+1]:
+        if searchtype == 'm' and searchterms:
+            page_authors = contains_page(Author.objects, 'opds_catalog_author', 'search_full_name',
+                                         searchterms.upper(), 'search_full_name', 'search_full_name',
+                                         op.d1_last_pos - op.d1_first_pos + 1, op.d1_first_pos)
+        else:
+            page_authors = authors[op.d1_first_pos:op.d1_last_pos+1]
+        for row in page_authors:
             p = {'id':row.id, 'full_name':row.full_name, 'lang_code': row.lang_code, 'book_count': Book.objects.filter(authors=row).count()}
             items.append(p)                     
             


### PR DESCRIPTION
## Symptom
Searching for a cyrillic book was very slow — while typing (live-search fires per keystroke) and on the search results themselves.

## Root cause (EXPLAIN ANALYZE, 240k-row cyrillic dataset)
The `pg_trgm` GIN indexes (migration `0011`) work — `COUNT(... LIKE '%term%')` uses the trigram bitmap (~12 ms). The villain is **`ORDER BY search_title`**: with a leading-wildcard `LIKE` it makes PostgreSQL drive off the plain **btree** index and filter row-by-row, ignoring the trigram index (~66–82 ms at 240k; seconds at multi-million rows, worst when matches sort late). Wrapping the filter in an `(... OFFSET 0)` fence forces "trigram bitmap → then sort" (~23 ms).

## Fix — applied to every substring (`'m'`) search
- **Live-search suggestions** (`SearchSuggestView`): drop `ORDER BY`, require ≥3 chars (a full trigram; matches the form's own minimum). This was the worst offender — per keystroke from 2 chars.
- **`utils.contains_page_ids()`**: OFFSET-0 fenced id query (PostgreSQL; plain ordered query on sqlite/mysql, which have no trigram index and reject bare `OFFSET`). **`utils.contains_page()`**: hydrates an ordered page from a base queryset via it.
- Rewired the `'m'` branch of: web **SearchBooksView**, **SearchAuthorsView**, **SearchSeriesView**, and OPDS **SearchBooksFeed** (incl. its doubles lookahead — previously random-access `books[finish]` btree hits + an N+1), **SearchAuthorsFeed**, **SearchSeriesFeed**. `COUNT` stays via the ORM (already trigram-fast); ordering, paging and doubles-dedup unchanged.

Untouched (no pathology): `'b'` prefix (btree serves it ordered), `'e'` exact, and FK-based searches (author/series/genre/bookshelf).

## Safety
`contains_page_ids` uses fixed identifiers from our own callers and a **bound, LIKE-escaped** term parameter (same safe pattern as `alphabet_menu`).

## Tests
`contains_page_ids` ordering/paging/filtering; books `'m'` order+dedup; authors `'m'`; series `'m'`; suggest ≥3-char boundary. Existing feed/search tests still pass. **`113 passed`**, `ruff` clean.

Note: `opds_catalog/feeds.py` is CRLF; the small fenced edits are LF (harmless — Python universal newlines). Not normalising the whole file to avoid a giant diff.