### PR TITLE
OPDS: authenticate Basic-auth against Keycloak (ROPC)

### DIFF
--- a/opds_catalog/middleware.py
+++ b/opds_catalog/middleware.py
@@ -46,9 +46,17 @@ class BasicAuthMiddleware(object):
         username, password = auth_data.split(':',1)            
 
         user = auth.authenticate(username=username, password=password)
+        if not (user and user.is_active):
+            # No local match: for OPDS clients (Basic auth only), validate the
+            # credentials against Keycloak via the ROPC grant so OIDC users can
+            # read feeds without a local password.
+            from sopds_web_backend import oidc
+            if oidc.oidc_enabled():
+                user = oidc.authenticate_password(username, password)
+
         if user and user.is_active:
             request.user = user
-            auth.login(request, user)
+            auth.login(request, user, backend='django.contrib.auth.backends.ModelBackend')
             return request
 
         return self.unauthed()

--- a/sopds_web_backend/oidc.py
+++ b/sopds_web_backend/oidc.py
@@ -5,13 +5,21 @@ they change. Endpoints are discovered from the issuer's
 ``.well-known/openid-configuration`` (so only the issuer URL is configured, not
 each endpoint).
 
-Scope: the browser login flow only. OPDS feeds keep HTTP Basic auth (e-readers
-cannot do an interactive redirect). Django admin access stays with local
-accounts — OIDC provisions regular (non-staff) users, and login is refused for
-usernames that already belong to a staff/superuser account.
+Browser login uses the OIDC redirect flow. OPDS feeds (e-readers) can't do an
+interactive redirect, so they send HTTP Basic auth; authenticate_password()
+below validates those credentials against Keycloak via the Resource Owner
+Password Credentials grant (requires "Direct Access Grants" enabled on the
+Keycloak client; no MFA). Django admin access stays with local accounts —
+OIDC provisions regular (non-staff) users, and login is refused for usernames
+that already belong to a staff/superuser account.
 """
+import hashlib
+
+import requests
 from authlib.integrations.django_client import OAuth
+from django.conf import settings
 from django.contrib.auth.models import User
+from django.core.cache import cache
 from constance import config
 
 _oauth = None
@@ -82,4 +90,69 @@ def provision_user(userinfo):
     if updates:
         user.save(update_fields=updates)
 
+    return user
+
+
+def _discovery():
+    """Fetch (and cache for an hour) the issuer's OIDC discovery document."""
+    issuer = config.SOPDS_OIDC_ISSUER.rstrip('/')
+    key = 'oidc:discovery:%s' % issuer
+    doc = cache.get(key)
+    if doc is None:
+        resp = requests.get('%s/.well-known/openid-configuration' % issuer, timeout=10)
+        resp.raise_for_status()
+        doc = resp.json()
+        cache.set(key, doc, 3600)
+    return doc
+
+
+def authenticate_password(username, password):
+    """Validate OPDS Basic-auth credentials against Keycloak (ROPC grant).
+
+    Returns the provisioned Django user, or None. A successful result is cached
+    briefly (keyed by a salted hash of the credentials, never the password
+    itself) so e-readers — which re-send Basic auth on every request — don't hit
+    Keycloak each time.
+    """
+    if not oidc_enabled() or not username or not password:
+        return None
+
+    cache_key = 'oidc:ropc:%s' % hashlib.sha256(
+        ('%s:%s:%s' % (username, password, settings.SECRET_KEY)).encode()).hexdigest()
+    cached_uid = cache.get(cache_key)
+    if cached_uid:
+        user = User.objects.filter(id=cached_uid, is_active=True).first()
+        if user and not (user.is_staff or user.is_superuser):
+            return user
+
+    try:
+        doc = _discovery()
+        data = {
+            'grant_type': 'password',
+            'client_id': config.SOPDS_OIDC_CLIENT_ID,
+            'username': username,
+            'password': password,
+            'scope': config.SOPDS_OIDC_SCOPES or 'openid email profile',
+        }
+        if config.SOPDS_OIDC_CLIENT_SECRET:
+            data['client_secret'] = config.SOPDS_OIDC_CLIENT_SECRET
+        resp = requests.post(doc['token_endpoint'], data=data, timeout=10)
+        if resp.status_code != 200:
+            return None
+        access_token = resp.json().get('access_token')
+        if not access_token:
+            return None
+        # Validate the token and get claims from the userinfo endpoint (returns
+        # 200 only for a valid token — the authoritative server-side check).
+        ur = requests.get(doc['userinfo_endpoint'],
+                          headers={'Authorization': 'Bearer %s' % access_token}, timeout=10)
+        if ur.status_code != 200:
+            return None
+        userinfo = ur.json()
+    except (requests.RequestException, KeyError, ValueError):
+        return None
+
+    user = provision_user(userinfo)
+    if user is not None:
+        cache.set(cache_key, user.id, 300)
     return user

--- a/sopds_web_backend/tests/test_opds_oidc_ropc.py
+++ b/sopds_web_backend/tests/test_opds_oidc_ropc.py
@@ -1,0 +1,83 @@
+"""OPDS Basic-auth -> Keycloak (ROPC) bridge: oidc.authenticate_password and
+the BasicAuthMiddleware fallback. Keycloak HTTP calls are mocked."""
+import base64
+
+import pytest
+from django.contrib.auth.models import User
+from django.core.cache import cache
+from constance import config
+
+from sopds_web_backend import oidc
+
+
+class _Resp:
+    def __init__(self, status=200, payload=None):
+        self.status_code = status
+        self._payload = payload or {}
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        pass
+
+
+@pytest.fixture
+def oidc_on(db):
+    config.SOPDS_AUTH = True
+    config.SOPDS_OIDC_ENABLE = True
+    config.SOPDS_OIDC_ISSUER = 'https://kc.example.com/realms/library'
+    config.SOPDS_OIDC_CLIENT_ID = 'sopds'
+    config.SOPDS_OIDC_CLIENT_SECRET = 'secret'
+    cache.clear()
+
+
+@pytest.fixture
+def discovery(monkeypatch):
+    monkeypatch.setattr(oidc, '_discovery', lambda: {
+        'token_endpoint': 'https://kc/t', 'userinfo_endpoint': 'https://kc/u'})
+
+
+@pytest.mark.django_db
+def test_ropc_success_provisions_user(oidc_on, discovery, monkeypatch):
+    monkeypatch.setattr(oidc.requests, 'post', lambda *a, **k: _Resp(200, {'access_token': 'AT'}))
+    monkeypatch.setattr(oidc.requests, 'get', lambda *a, **k: _Resp(200, {'preferred_username': 'reader', 'email': 'r@x.y'}))
+    user = oidc.authenticate_password('reader', 'pw')
+    assert user is not None and user.username == 'reader' and user.is_active
+
+
+@pytest.mark.django_db
+def test_ropc_bad_credentials(oidc_on, discovery, monkeypatch):
+    monkeypatch.setattr(oidc.requests, 'post', lambda *a, **k: _Resp(401, {'error': 'invalid_grant'}))
+    assert oidc.authenticate_password('reader', 'wrong') is None
+
+
+@pytest.mark.django_db
+def test_ropc_disabled_returns_none(db):
+    config.SOPDS_OIDC_ENABLE = False
+    assert oidc.authenticate_password('reader', 'pw') is None
+
+
+@pytest.mark.django_db
+def test_ropc_denies_staff(oidc_on, discovery, monkeypatch):
+    User.objects.create_user('boss', 'b@x.y', 'pw', is_staff=True)
+    monkeypatch.setattr(oidc.requests, 'post', lambda *a, **k: _Resp(200, {'access_token': 'AT'}))
+    monkeypatch.setattr(oidc.requests, 'get', lambda *a, **k: _Resp(200, {'preferred_username': 'boss'}))
+    assert oidc.authenticate_password('boss', 'pw') is None
+
+
+@pytest.mark.django_db
+def test_opds_feed_basic_auth_via_ropc(client, oidc_on, monkeypatch):
+    kc_user = User.objects.create_user('kcreader', 'k@x.y', '!unusable')
+    monkeypatch.setattr(oidc, 'authenticate_password', lambda u, p: kc_user)
+    hdr = 'Basic ' + base64.b64encode(b'kcreader:kcpassword').decode()
+    resp = client.get('/opds/', HTTP_AUTHORIZATION=hdr)
+    assert resp.status_code == 200
+
+
+@pytest.mark.django_db
+def test_opds_feed_basic_auth_rejected(client, oidc_on, monkeypatch):
+    monkeypatch.setattr(oidc, 'authenticate_password', lambda u, p: None)
+    hdr = 'Basic ' + base64.b64encode(b'nobody:bad').decode()
+    resp = client.get('/opds/', HTTP_AUTHORIZATION=hdr)
+    assert resp.status_code == 401


### PR DESCRIPTION
## Problem
E-readers speak only HTTP Basic auth and can't complete the OIDC redirect, so Keycloak users couldn't authenticate to the OPDS feeds (they have no local Django password).

## Fix — validate Basic-auth against Keycloak (ROPC)
When local auth fails **and** OIDC is enabled, `BasicAuthMiddleware` now calls `oidc.authenticate_password(username, password)`:
1. Discover the token endpoint from the issuer (`_discovery`, cached 1h).
2. Keycloak **ROPC** grant (`grant_type=password`, client id/secret from constance).
3. Confirm the token at the **userinfo** endpoint (authoritative check) and `provision_user()` the claims — which still **refuses staff/superuser takeover**.

A successful result is cached ~5 min, keyed by a **salted hash of the credentials** (never the password), so e-readers re-sending Basic auth every request don't hammer Keycloak.

The user types their **normal Keycloak username/password** in the reader — no extra step.

## Requirements / notes
- **Enable "Direct Access Grants" on the Keycloak client** (Clients → your client → Capability config → Direct access grants). Without it, ROPC returns 400/401 and OPDS login fails.
- **No MFA** with ROPC (password grant). If MFA is required, we'd need the app-password approach (option B) instead.
- Local Django passwords still work for OPDS; behaviour is unchanged when OIDC is off. Web login (redirect flow) is unchanged.
- The app forwards the password to Keycloak only; it is never stored.

## Tests
`test_opds_oidc_ropc.py` mocks the Keycloak HTTP calls: success provisions a user; bad credentials → None; disabled → None; staff username → denied; plus the middleware fallback on a real `/opds/` request (200 with a valid KC user, 401 otherwise). `127 passed`, `ruff` clean.

## NOT validated
A live ROPC round-trip against the real Keycloak (needs Direct Access Grants on). Manual check: point an OPDS reader at the catalog, enter Keycloak username/password, confirm feeds load.
