### PR TITLE
Add (lang_code, search_title) index for the alphabet menu

### DIFF
--- a/opds_catalog/migrations/0016_book_lang_search_title_index.py
+++ b/opds_catalog/migrations/0016_book_lang_search_title_index.py
@@ -1,0 +1,44 @@
+# Composite index for the alphabet "select by substring" menu (BooksView /
+# AuthorsView / SeriesView and the OPDS *Feed equivalents), which run
+#   SELECT substr(search_title,1,1), count(*) FROM opds_catalog_book
+#   WHERE lang_code = %s [AND search_title LIKE %s] GROUP BY substr(...)
+# via opds_catalog.utils.alphabet_menu.
+#
+# Without (lang_code, search_title) Postgres scanned the lang_code btree and
+# then did ~33k random heap fetches to read search_title for the substr()
+# grouping (or seq-scanned the whole 3 GB table), ~17-21 s cold on a large
+# catalog. With this composite index the query is an Index Only Scan
+# (Heap Fetches: 0) grouped in index order -> sub-second.
+#
+# PostgreSQL only, guarded by connection.vendor (mirrors migrations 0011/0012).
+from django.db import migrations
+
+
+INDEX_NAME = "opds_catalog_book_lang_stitle"
+TABLE = "opds_catalog_book"
+
+
+def create_index(apps, schema_editor):
+    if schema_editor.connection.vendor != "postgresql":
+        return
+    schema_editor.execute(
+        'CREATE INDEX IF NOT EXISTS "%s" ON "%s" ("lang_code", "search_title")'
+        % (INDEX_NAME, TABLE)
+    )
+
+
+def drop_index(apps, schema_editor):
+    if schema_editor.connection.vendor != "postgresql":
+        return
+    schema_editor.execute('DROP INDEX IF EXISTS "%s"' % INDEX_NAME)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("opds_catalog", "0015_bookshelf_status_rating"),
+    ]
+
+    operations = [
+        migrations.RunPython(create_index, drop_index),
+    ]


### PR DESCRIPTION
## Problem

Entering **Books / Authors / Series** in the web UI (e.g. `/web/book/?lang=2`) took **~17 s** on a cold cache on the production catalog (~700k books, ~3 GB `opds_catalog_book`). OPDS felt fine only because its "Books" entry point is a static language list (`LangFeed`) that does not run the aggregate.

The slow part is the alphabet "select by substring" query built by `opds_catalog.utils.alphabet_menu`:

```sql
SELECT substr(search_title, 1, 1), count(*)
FROM opds_catalog_book
WHERE lang_code = %s [AND search_title LIKE %s]
GROUP BY substr(search_title, 1, 1)
```

No index covered both `lang_code` and `search_title`, so PostgreSQL either sequential-scanned the whole 3 GB table or index-scanned `lang_code` and then did tens of thousands of random **heap fetches** to read `search_title` for the `substr()` grouping. The page cache hides this once warm, so only the first hit per cache window paid the cost — but that first hit was 17-21 s.

## Fix

Add a composite btree on **`(lang_code, search_title)`**. The query becomes an **Index Only Scan (Heap Fetches: 0)** grouped in index order.

Measured on production (699,428 books, PostgreSQL 16.9), `EXPLAIN ANALYZE`:

| Query | Before | After |
|---|---|---|
| `lang=2` (latin) | 6.8 s warm / ~17 s cold | **67 ms** |
| `lang=1` (cyrillic, 626k rows) | ~20 s | **~430 ms** |
| drill-down `LIKE 'А%'` | — | **206 ms** |

The cold path is now bounded by a ~40 MB index read instead of the 3 GB heap. The existing degenerate `AND search_title LIKE '%'` (empty prefix) no longer forces a sequential scan once `search_title` is in the index, so no view/query change is required.

## Notes

- PostgreSQL-only, guarded by `connection.vendor` and created with `IF NOT EXISTS` (mirrors migrations `0011`/`0012`) — a no-op on other backends and on deployments where the index was already created out of band.
- The index has already been created on production (`CREATE INDEX CONCURRENTLY`); this migration makes it reproducible for fresh deploys and records it in migration history.