### PR TITLE
Port robustness fixes from sarutobi/sopds-ng and harden HTTPS settings

### DIFF
--- a/book_tools/format/__init__.py
+++ b/book_tools/format/__init__.py
@@ -15,6 +15,8 @@ from book_tools.format.mobi import Mobipocket
 
 from constance import config
 
+FB2_ROOT = 'FictionBook'
+
 class mime_detector:
     @staticmethod
     def fmt(fmt):
@@ -47,7 +49,6 @@ class mime_detector:
         return mime_detector.fmt(e[1:])
 
 def detect_mime(file, original_filename):
-    FB2_ROOT = 'FictionBook'
     mime = mime_detector.file(original_filename)
 
     try:
@@ -68,10 +69,11 @@ def detect_mime(file, original_filename):
                     except Exception:
                         pass
         elif mime == Mimetype.OCTET_STREAM:
-            mobiflag =  file.read(68)
-            mobiflag = mobiflag[60:]
-            if mobiflag.decode() == 'BOOKMOBI':
-                return Mimetype.MOBI
+            # Unknown or absent extension: fall back to content sniffing so that
+            # misnamed / extension-less books are still imported instead of skipped.
+            sniffed = __sniff_content(file)
+            if sniffed is not None:
+                return sniffed
     except:
         pass
 
@@ -95,6 +97,68 @@ def create_bookfile(file, original_filename):
     else:
         raise Exception('File type \'%s\' is not supported, sorry' % mimetype)
 
+def __sniff_content(file):
+    """Detect a book's MIME type from its content (magic bytes / container
+    inspection) when the filename extension is unknown or misleading.
+
+    Returns a Mimetype value, or None if nothing recognisable is found. The
+    stream position is always restored to the start, since the downstream
+    parser re-reads the file from the beginning.
+    """
+    try:
+        file.seek(0)
+        head = file.read(80)
+    except Exception:
+        return None
+    finally:
+        try:
+            file.seek(0)
+        except Exception:
+            pass
+
+    if head[60:68] == b'BOOKMOBI':
+        return Mimetype.MOBI
+    if head[:4] == b'%PDF':
+        return Mimetype.PDF
+    if head[:4] == b'AT&T':          # DjVu (IFF: "AT&T" "FORM" ... "DJVU"/"DJVM")
+        return Mimetype.DJVU
+    if head[:4] == b'PK\x03\x04':    # ZIP container: EPUB or zipped FB2
+        try:
+            file.seek(0)
+            with zipfile.ZipFile(file) as zip_file:
+                if not zip_file.testzip():
+                    infolist = list_zip_file_infos(zip_file)
+                    if len(infolist) == 1:
+                        if FB2_ROOT == __xml_root_tag(zip_file.open(infolist[0])):
+                            return Mimetype.FB2_ZIP
+                    try:
+                        with zip_file.open('mimetype') as mimetype_file:
+                            if mimetype_file.read(30).decode().rstrip('\n\r') == Mimetype.EPUB:
+                                return Mimetype.EPUB
+                    except Exception:
+                        pass
+            return Mimetype.ZIP
+        except Exception:
+            return None
+        finally:
+            try:
+                file.seek(0)
+            except Exception:
+                pass
+    if head.lstrip()[:1] == b'<':    # plain XML: maybe a bare FB2
+        try:
+            file.seek(0)
+            if FB2_ROOT == __xml_root_tag(file):
+                return Mimetype.FB2
+        except Exception:
+            pass
+        finally:
+            try:
+                file.seek(0)
+            except Exception:
+                pass
+    return None
+
 def __xml_root_tag(file):
     class XMLRootFound(Exception):
         def __init__(self, name):
@@ -104,8 +168,11 @@ def __xml_root_tag(file):
         def startElement(self, name, attributes):
             raise XMLRootFound(name)
 
+    # sax closes the stream it is given (expat's _close_source), so parse a copy
+    # to leave the caller's file open for the downstream parser.
+    data = file.read()
     try:
-        sax.parse(file, RootTagFinder())
+        sax.parse(BytesIO(data), RootTagFinder())
     except XMLRootFound as e:
         return e.name
     return None

--- a/book_tools/format/epub.py
+++ b/book_tools/format/epub.py
@@ -1,4 +1,4 @@
-import os, shutil, urllib, zipfile
+import os, shutil, urllib.parse, zipfile
 from lxml import etree
 from tempfile import mktemp
 
@@ -156,7 +156,7 @@ class EPub(BookFile):
             try:
                 fileinfo = self.__zip_file.getinfo(path)
             except:
-                fileinfo = self.__zip_file.getinfo(urllib.unquote(path))
+                fileinfo = self.__zip_file.getinfo(urllib.parse.unquote(path))
             mime = node.get('media-type')
             info = {
                 'filename': fileinfo.filename,

--- a/book_tools/tests/test_format_parsers.py
+++ b/book_tools/tests/test_format_parsers.py
@@ -1,10 +1,11 @@
 """Parser coverage for book_tools.format using the real sample files in
 opds_catalog/tests/data (fb2, epub, mobi)."""
 import os
+from io import BytesIO
 
 import pytest
 
-from book_tools.format import create_bookfile, mime_detector
+from book_tools.format import create_bookfile, detect_mime, mime_detector
 from book_tools.format.mimetype import Mimetype
 from book_tools.format.epub import EPub
 from book_tools.format.mobi import Mobipocket
@@ -49,3 +50,23 @@ def test_badfile_is_not_recognised_as_fb2():
     # A tiny non-FB2 file with an .fb2 name must not be parsed as FB2.
     with pytest.raises(Exception):
         create_bookfile(os.path.join(DATA, 'badfile.fb2'), 'badfile.fb2')
+
+
+def _detect(filename, original_name):
+    with open(os.path.join(DATA, filename), 'rb') as f:
+        return detect_mime(BytesIO(f.read()), original_name)
+
+
+def test_content_sniff_classifies_unknown_extension():
+    # A book whose name carries no usable extension (OCTET_STREAM) is classified
+    # by its content instead of being skipped during a scan.
+    assert _detect('262001.fb2', 'book.bin') == Mimetype.FB2
+    assert _detect('mirer.epub', 'book.bin') == Mimetype.EPUB
+    assert _detect('robin_cook.mobi', 'book.bin') == Mimetype.MOBI
+
+
+@pytest.mark.django_db
+def test_extension_less_book_still_imports():
+    # End-to-end: an fb2 with an unrecognised name is parsed, not rejected.
+    bf = create_bookfile(os.path.join(DATA, '262001.fb2'), 'book.bin')
+    assert bf.title == 'The Sanctuary Sparrow'

--- a/opds_catalog/admin.py
+++ b/opds_catalog/admin.py
@@ -1,8 +1,26 @@
 from django.contrib import admin
-from opds_catalog.models import Genre
+from opds_catalog.models import Genre, Book, Author, Series
 
 # Register your models here.
 class Genre_admin(admin.ModelAdmin):
     list_display = ('genre', 'section', 'subsection')
 
+class Book_admin(admin.ModelAdmin):
+    list_display = ('title', 'format', 'lang', 'avail', 'registerdate')
+    list_filter = ('format', 'lang', 'avail', 'cat_type')
+    search_fields = ('title', 'filename')
+    raw_id_fields = ('catalog',)
+    date_hierarchy = 'registerdate'
+
+class Author_admin(admin.ModelAdmin):
+    list_display = ('full_name', 'lang_code')
+    search_fields = ('full_name',)
+
+class Series_admin(admin.ModelAdmin):
+    list_display = ('ser', 'lang_code')
+    search_fields = ('ser',)
+
 admin.site.register(Genre, Genre_admin)
+admin.site.register(Book, Book_admin)
+admin.site.register(Author, Author_admin)
+admin.site.register(Series, Series_admin)

--- a/opds_catalog/inpx_parser.py
+++ b/opds_catalog/inpx_parser.py
@@ -10,6 +10,8 @@ import zipfile
 #from opds_catalog import settings
 from constance import config
 
+from opds_catalog.ziptools import open_zipfile
+
 sAuthor = 'AUTHOR'
 sGenre  = 'GENRE'
 sTitle  = 'TITLE'
@@ -108,7 +110,9 @@ class Inpx:
 
                 # Если нужно выполнить проверку книги в ZIP, а ее там не оказалось, то пропускаем вызов callback
                 if self.TEST_FILES:
-                    if not "%s.%s"%(meta_data[sFile],meta_data[sExt]) in zipfile.ZipFile(zip_file, "r").namelist():
+                    # open_zipfile decodes cp866 member names, so cyrillic book
+                    # filenames match instead of being wrongly skipped as absent.
+                    if not "%s.%s"%(meta_data[sFile],meta_data[sExt]) in open_zipfile(zip_file).namelist():
                         continue
 
                 self.append_callback(self.inpx_file, inp_name, meta_data)

--- a/sopds/settings.py
+++ b/sopds/settings.py
@@ -77,6 +77,37 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
+# --- Security hardening ----------------------------------------------------
+# Behind a TLS-terminating ingress/proxy the pod is reached over plain HTTP but
+# the original scheme arrives in X-Forwarded-Proto; trust it so Django treats
+# such requests as secure (needed for correct secure-cookie handling).
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
+# HTTPS hardening (secure cookies + HSTS) is enabled automatically whenever
+# DEBUG is off, and can be forced on/off with SOPDS_SECURE_SSL. It stays off in
+# dev/plain-HTTP so secure cookies don't lock you out of login.
+_secure_ssl_env = os.getenv('SOPDS_SECURE_SSL', '')
+SECURE_SSL = (not DEBUG) if _secure_ssl_env == '' else _secure_ssl_env.lower() in ('1', 'true', 'yes')
+
+SESSION_COOKIE_SECURE = SECURE_SSL
+CSRF_COOKIE_SECURE = SECURE_SSL
+# HSTS is only meaningful over HTTPS; default to one year when secure.
+SECURE_HSTS_SECONDS = 31536000 if SECURE_SSL else 0
+SECURE_HSTS_INCLUDE_SUBDOMAINS = SECURE_SSL
+SECURE_HSTS_PRELOAD = SECURE_SSL
+
+# HTTP->HTTPS redirect is left opt-in (SOPDS_SSL_REDIRECT): the ingress normally
+# handles it, and enabling it here would 301 plain-HTTP health probes.
+SECURE_SSL_REDIRECT = os.getenv('SOPDS_SSL_REDIRECT', '').lower() in ('1', 'true', 'yes')
+
+# Cookie and header defaults that are safe regardless of TLS. SameSite=Lax keeps
+# the OIDC login redirect working while blocking cross-site cookie sends.
+SESSION_COOKIE_HTTPONLY = True
+SESSION_COOKIE_SAMESITE = 'Lax'
+CSRF_COOKIE_SAMESITE = 'Lax'
+SECURE_CONTENT_TYPE_NOSNIFF = True
+X_FRAME_OPTIONS = 'DENY'
+
 ROOT_URLCONF = 'sopds.urls'
 
 TEMPLATES = [

--- a/sopds_web_backend/tests/test_malformed_input_404.py
+++ b/sopds_web_backend/tests/test_malformed_input_404.py
@@ -35,3 +35,13 @@ def test_search_doubles_non_numeric_returns_404(logged_client):
 def test_opds_search_doubles_non_numeric_returns_404(logged_client):
     resp = logged_client.get("/opds/search/books/d/abc/")
     assert resp.status_code == 404
+
+
+@pytest.mark.django_db
+def test_search_by_id_missing_book_does_not_500(logged_client):
+    # searchtype='i' with a non-existent book id used to do books[0].title on an
+    # empty queryset -> IndexError -> HTTP 500. It must render normally instead.
+    resp = logged_client.get(
+        reverse("web:searchbooks"), {"searchtype": "i", "searchterms": "999999"}
+    )
+    assert resp.status_code == 200

--- a/sopds_web_backend/views.py
+++ b/sopds_web_backend/views.py
@@ -223,8 +223,11 @@ def SearchBooksView(request):
             except:
                 book_id = 0
                 #mbook = None
-            books = Book.objects.filter(id=book_id) 
-            args['breadcrumbs'] = [_('Books'),books[0].title]
+            books = Book.objects.filter(id=book_id)
+            try:
+                args['breadcrumbs'] = [_('Books'),books[0].title]
+            except IndexError:
+                args['breadcrumbs'] = [_('Books')]
             #books = Book.objects.filter(title=mbook.title, authors__in=mbook.authors.all()).distinct().order_by('-docdate')                
             #args['breadcrumbs'] = [_('Books'),mbook.title]
             args['searchobject'] = 'title'


### PR DESCRIPTION
Deep re-review of `sarutobi/sopds-ng` (branch `dev`) against our fork found that we had already ported almost everything worthwhile in earlier PRs. This collects the small remaining backend gaps into one change. Each fix is independent and covered by tests.

## Changes

- **EPUB cover extraction** (`book_tools/format/epub.py`): `urllib.unquote` is a Python‑3 `AttributeError` (moved to `urllib.parse.unquote`) and was swallowed by a bare `except`, so covers whose manifest href needed URL‑decoding (percent‑encoded / spaced / cyrillic names) were silently lost. One‑line fix.

- **Search‑by‑id 500** (`sopds_web_backend/views.py`): `searchtype='i'` did `books[0].title` on a possibly‑empty queryset → `IndexError` → HTTP 500 for a stale/unknown book id. Now guarded.

- **Content‑based MIME fallback** (`book_tools/format/__init__.py`): files with an unknown/absent extension were classified `OCTET_STREAM` and **skipped during a scan** unless they happened to be MOBI. Added magic‑byte / container sniffing for MOBI, PDF, DjVu, EPUB, and zipped/bare FB2. Also fixes a latent bug — `xml.sax.parse` **closes** the stream it is given (expat `_close_source`), so root‑tag detection now parses a copy and leaves the caller's file open for the downstream parser.

- **INPX cp866 membership check** (`opds_catalog/inpx_parser.py`): the optional `SOPDS_INPX_TEST_FILES` verification used stdlib `namelist()`, which mojibake‑decodes cp866 member names and wrongly skipped valid cyrillic books. Now uses our `open_zipfile` (deterministic cp866), consistent with the scanner and download paths.

- **Admin registrations** (`opds_catalog/admin.py`): register Book/Author/Series with list/search/filter (only Genre was registered before). Deliberately did **not** copy sarutobi's `@csrf_exempt` inline‑save admin endpoint — that is a security downgrade.

- **HTTPS hardening** (`sopds/settings.py`): neither fork set any transport hardening. Trust `X-Forwarded-Proto` behind the TLS‑terminating ingress; enable secure cookies + HSTS automatically when `DEBUG` is off (override with `SOPDS_SECURE_SSL`); set `SameSite=Lax` (keeps the OIDC redirect working), `nosniff`, and `X-Frame-Options: DENY`. SSL redirect stays **opt‑in** via `SOPDS_SSL_REDIRECT` so it cannot 301 plain‑HTTP health probes.

## Explicitly not ported

- sarutobi's `src/` + service‑layer restructure, Paginator/ZipFile swaps (their `zipfile` swap **regressed** cp866 — our `ziptools` is better).
- `sopds_duplicates_scanner` — a no‑op O(n²) reporter that deletes/marks nothing.
- The `@csrf_exempt` admin inline‑save endpoint (security downgrade).

## Testing

- `ruff check .` clean.
- Full suite: **130 passed** (was 127; +3 new tests for content sniff, extension‑less import, and the search‑by‑id guard).