### PR TITLE
Scanner: PG advisory lock + post-scan VACUUM (incident prevention)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,13 @@ All notable changes to this project are documented here. The format is based on
 - The library scan now commits per directory (with the delete-sweep kept
   atomic) instead of wrapping the whole walk in one transaction, so an
   interrupted scan keeps its progress and holds no multi-hour lock.
+- Scan mutual-exclusion uses a PostgreSQL **session advisory lock** (with a
+  pidfile-flock fallback on other backends): it is released automatically when
+  the scanner process/pod dies, so an interrupted scan can no longer overlap
+  the next one across restarts.
+- The scanner runs `VACUUM (ANALYZE)` on the catalog tables after each scan, so
+  the full-table `avail` sweep no longer leaves the alphabet-menu queries
+  slow (lost Index-Only Scan) until autovacuum catches up.
 
 ### Security
 - Brute-force throttle on the web login form: after 10 failed attempts per

--- a/opds_catalog/management/commands/sopds_scanner.py
+++ b/opds_catalog/management/commands/sopds_scanner.py
@@ -12,8 +12,13 @@ from django.core.management.base import BaseCommand
 from django.db import connection, connections
 from django.conf import settings as main_settings
 
+from opds_catalog import opdsdb
 from opds_catalog.models import Counter
 from opds_catalog.sopdscan import opdsScanner
+
+# Fixed key for the scan's PostgreSQL session-level advisory lock. Arbitrary but
+# stable; shared by every scanner process against the same database.
+SCAN_ADVISORY_LOCK_KEY = 0x50D5_5CA4  # "SOPDS SCAN" mnemonic, fits a signed bigint
 #from opds_catalog.settings import SCANNER_LOG, SCAN_SHED_DAY, SCAN_SHED_DOW, SCAN_SHED_HOUR, SCAN_SHED_MIN, LOGLEVEL, SCANNER_PID
 from opds_catalog import settings 
 from constance import config
@@ -100,29 +105,61 @@ class Command(BaseCommand):
         finally:
             fd.close()
 
+    def _acquire_scan_lock(self):
+        """Acquire an exclusive scan lock; return a release callable, or None
+        if another scan already holds it.
+
+        On PostgreSQL use a **session-level advisory lock**: it is bound to the
+        DB connection, so it is released automatically when the scanner
+        process/pod dies mid-scan. A pidfile flock (below) is per-pod and goes
+        stale across pod restarts, which is why an interrupted scan could
+        overlap the next one. On other backends (dev/sqlite) fall back to the
+        flock.
+        """
+        if connection.vendor == 'postgresql':
+            with connection.cursor() as cursor:
+                cursor.execute('SELECT pg_try_advisory_lock(%s)', [SCAN_ADVISORY_LOCK_KEY])
+                if not cursor.fetchone()[0]:
+                    return None
+            return self._release_pg_lock
+        fd = self._acquire_lock()
+        if fd is None:
+            return None
+        return lambda: self._release_lock(fd)
+
+    @staticmethod
+    def _release_pg_lock():
+        with connection.cursor() as cursor:
+            cursor.execute('SELECT pg_advisory_unlock(%s)', [SCAN_ADVISORY_LOCK_KEY])
+
     def scan(self):
         if self.scan_is_active:
             self.stdout.write('Scan process already active. Skip currend job.')
             return
 
-        lock_fd = self._acquire_lock()
-        if lock_fd is None:
+        # Refresh a stale pooled connection before locking/scanning on it.
+        if connection.connection and not connection.is_usable():
+            connection.close()
+
+        release_lock = self._acquire_scan_lock()
+        if release_lock is None:
             self.stdout.write('Another scan is already running (locked). Skip current job.')
             return
 
         self.scan_is_active = True
         try:
-            if connection.connection and not connection.is_usable():
-                del(connections._connections.default)
-
             scanner=opdsScanner(self.logger)
-            # scan_all() now commits per directory (and keeps the delete-sweep
+            # scan_all() commits per directory (and keeps the delete-sweep
             # atomic on its own), so it is not wrapped in one giant transaction.
             scanner.scan_all()
             Counter.objects.update_known_counters()
+            # Reclaim the dead tuples the avail sweep churns and refresh stats /
+            # the visibility map, so post-scan reads keep their Index-Only Scans
+            # instead of slowing to tens of seconds until autovacuum catches up.
+            opdsdb.vacuum_analyze()
         finally:
             self.scan_is_active = False
-            self._release_lock(lock_fd)
+            release_lock()
         
     def update_shedule(self):
         self.SCAN_SHED_DAY = config.SOPDS_SCAN_SHED_DAY

--- a/opds_catalog/opdsdb.py
+++ b/opds_catalog/opdsdb.py
@@ -54,6 +54,24 @@ def pg_optimize(verbose=False):
         cursor.execute('VACUUM FULL opds_catalog_book')
         print('PostgreSql tables internal structure optimized...')
 
+def vacuum_analyze(verbose=False):
+    """VACUUM ANALYZE the large catalog tables (PostgreSQL only).
+
+    Run after a scan: the full-table ``avail`` sweep churns every row, so
+    without this the tables accumulate dead tuples and a stale visibility map
+    until autovacuum catches up, during which the alphabet menu loses its
+    Index-Only Scan and slows to tens of seconds. VACUUM (not FULL) is
+    non-blocking. Safe to skip on non-PostgreSQL backends.
+    """
+    if connection.vendor != 'postgresql':
+        return
+    with connection.cursor() as cursor:
+        for table in ('opds_catalog_book', 'opds_catalog_author', 'opds_catalog_series'):
+            if verbose:
+                print('VACUUM (ANALYZE) %s ...' % table)
+            cursor.execute('VACUUM (ANALYZE) %s' % table)
+
+
 def clear_all(verbose=False):
     cursor = connection.cursor()
     cursor.execute('delete from opds_catalog_bseries')

--- a/opds_catalog/tests/test_scan_lock.py
+++ b/opds_catalog/tests/test_scan_lock.py
@@ -24,3 +24,19 @@ def test_scan_lock_is_exclusive(tmp_path):
     fd3 = cmd._acquire_lock()      # released -> available again
     assert fd3 is not None
     cmd._release_lock(fd3)
+
+
+def test_acquire_scan_lock_is_exclusive(tmp_path):
+    # The vendor dispatch: on sqlite (tests) it falls back to the flock and
+    # returns a release callable; a second acquisition is refused until release.
+    cmd = Command()
+    cmd.pidfile = str(tmp_path / 's.pid')
+
+    release = cmd._acquire_scan_lock()
+    assert callable(release)
+    assert cmd._acquire_scan_lock() is None   # held
+
+    release()
+    release2 = cmd._acquire_scan_lock()       # available again
+    assert callable(release2)
+    release2()

--- a/opds_catalog/tests/test_vacuum_analyze.py
+++ b/opds_catalog/tests/test_vacuum_analyze.py
@@ -1,0 +1,10 @@
+"""opdsdb.vacuum_analyze() is a safe no-op on non-PostgreSQL backends."""
+import pytest
+
+from opds_catalog import opdsdb
+
+
+@pytest.mark.django_db
+def test_vacuum_analyze_noop_on_sqlite():
+    # The test DB is sqlite; vacuum_analyze must return without raising.
+    opdsdb.vacuum_analyze()


### PR DESCRIPTION
## Summary

Prevention for a production incident: a library scan's full-table
`avail_check_prepare` UPDATE (`SET avail=1`) was orphaned when a pod restart
(deploy) killed the scanner, kept running in Postgres for ~2h churning the
699k-row / 1.9 GB book table, evicting shared_buffers and leaving a stale
visibility map — so `/web/book/?lang=1` lost its Index-Only Scan and took tens
of seconds. (Mitigated live: terminated the orphaned backend + `VACUUM ANALYZE`.)

**Stacked on `fix/deep-review` (#54)** — base branch is `fix/deep-review`;
retarget to `master` once #54 merges.

## Changes

- **PostgreSQL session advisory lock** for scan mutual-exclusion
  (`pg_try_advisory_lock`) instead of the pidfile flock. It is bound to the DB
  connection, so it releases automatically when the scanner process/pod dies —
  a flock is per-pod and goes stale across restarts, which is exactly how the
  interrupted scan overlapped. Falls back to the flock on non-PostgreSQL.
- **`VACUUM (ANALYZE)` after each scan** (`opdsdb.vacuum_analyze`, PG-only) so
  the `avail` sweep's churn doesn't leave the alphabet-menu Index-Only Scans
  slow until autovacuum catches up.
- Refresh a stale connection via `connection.close()` instead of poking
  `connections._connections`.

Tests: advisory/flock dispatch exclusivity, `vacuum_analyze` no-op on sqlite.
166 tests pass; `ruff` clean.

## Companion (separate, sopds-k8s)

`client_connection_check_interval=10s` on the Postgres cluster so a backend
self-cancels within ~10s when its client (scanner pod) disconnects — the direct
fix for the orphaning itself. Applied to the deploy repo, not this PR.

## Follow-up (not here)

The full-table `avail` UPDATE on every scan is the underlying churn source;
redesigning it (e.g. a per-pass seen-id set + single anti-join delete) would
avoid rewriting the whole table each scan.
