### PR TITLE
Scan: seen-set anti-join instead of the full-table avail sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ All notable changes to this project are documented here. The format is based on
 - Tooling config in `pyproject.toml` (ruff, mypy); `CONTRIBUTING.md`.
 
 ### Changed
+- Incremental scan no longer rewrites the whole `Book` table on every run. The
+  start-of-scan `UPDATE opds_catalog_book SET avail=1` full-table sweep is
+  replaced by a scratch `ScanSeen` table: the scanner records the id of each
+  book it re-finds or adds, and the post-walk pass deletes only the books not
+  seen (anti-join). Unchanged books are never rewritten — no bloat and no
+  read-slowdown during a scan — and the sweep refuses to run if the seen set is
+  empty (never wipes a non-empty catalogue). Adds migration `0017`.
 - Upgraded to Django 5.2 LTS (Python 3.13 / PostgreSQL supported).
 - Test dependencies are constrained by `requirements.txt` (`requirements-test.txt`
   uses `-c`), so the test environment never drifts from production.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,13 @@ All notable changes to this project are documented here. The format is based on
 - The library scan now commits per directory (with the delete-sweep kept
   atomic) instead of wrapping the whole walk in one transaction, so an
   interrupted scan keeps its progress and holds no multi-hour lock.
+- Scan mutual-exclusion uses a PostgreSQL **session advisory lock** (with a
+  pidfile-flock fallback on other backends): it is released automatically when
+  the scanner process/pod dies, so an interrupted scan can no longer overlap
+  the next one across restarts.
+- The scanner runs `VACUUM (ANALYZE)` on the catalog tables after each scan, so
+  the full-table `avail` sweep no longer leaves the alphabet-menu queries
+  slow (lost Index-Only Scan) until autovacuum catches up.
 
 ### Security
 - Brute-force throttle on the web login form: after 10 failed attempts per

--- a/opds_catalog/management/commands/sopds_scanner.py
+++ b/opds_catalog/management/commands/sopds_scanner.py
@@ -12,8 +12,13 @@ from django.core.management.base import BaseCommand
 from django.db import connection, connections
 from django.conf import settings as main_settings
 
+from opds_catalog import opdsdb
 from opds_catalog.models import Counter
 from opds_catalog.sopdscan import opdsScanner
+
+# Fixed key for the scan's PostgreSQL session-level advisory lock. Arbitrary but
+# stable; shared by every scanner process against the same database.
+SCAN_ADVISORY_LOCK_KEY = 0x50D5_5CA4  # "SOPDS SCAN" mnemonic, fits a signed bigint
 #from opds_catalog.settings import SCANNER_LOG, SCAN_SHED_DAY, SCAN_SHED_DOW, SCAN_SHED_HOUR, SCAN_SHED_MIN, LOGLEVEL, SCANNER_PID
 from opds_catalog import settings 
 from constance import config
@@ -100,29 +105,61 @@ class Command(BaseCommand):
         finally:
             fd.close()
 
+    def _acquire_scan_lock(self):
+        """Acquire an exclusive scan lock; return a release callable, or None
+        if another scan already holds it.
+
+        On PostgreSQL use a **session-level advisory lock**: it is bound to the
+        DB connection, so it is released automatically when the scanner
+        process/pod dies mid-scan. A pidfile flock (below) is per-pod and goes
+        stale across pod restarts, which is why an interrupted scan could
+        overlap the next one. On other backends (dev/sqlite) fall back to the
+        flock.
+        """
+        if connection.vendor == 'postgresql':
+            with connection.cursor() as cursor:
+                cursor.execute('SELECT pg_try_advisory_lock(%s)', [SCAN_ADVISORY_LOCK_KEY])
+                if not cursor.fetchone()[0]:
+                    return None
+            return self._release_pg_lock
+        fd = self._acquire_lock()
+        if fd is None:
+            return None
+        return lambda: self._release_lock(fd)
+
+    @staticmethod
+    def _release_pg_lock():
+        with connection.cursor() as cursor:
+            cursor.execute('SELECT pg_advisory_unlock(%s)', [SCAN_ADVISORY_LOCK_KEY])
+
     def scan(self):
         if self.scan_is_active:
             self.stdout.write('Scan process already active. Skip currend job.')
             return
 
-        lock_fd = self._acquire_lock()
-        if lock_fd is None:
+        # Refresh a stale pooled connection before locking/scanning on it.
+        if connection.connection and not connection.is_usable():
+            connection.close()
+
+        release_lock = self._acquire_scan_lock()
+        if release_lock is None:
             self.stdout.write('Another scan is already running (locked). Skip current job.')
             return
 
         self.scan_is_active = True
         try:
-            if connection.connection and not connection.is_usable():
-                del(connections._connections.default)
-
             scanner=opdsScanner(self.logger)
-            # scan_all() now commits per directory (and keeps the delete-sweep
+            # scan_all() commits per directory (and keeps the delete-sweep
             # atomic on its own), so it is not wrapped in one giant transaction.
             scanner.scan_all()
             Counter.objects.update_known_counters()
+            # Reclaim the dead tuples the avail sweep churns and refresh stats /
+            # the visibility map, so post-scan reads keep their Index-Only Scans
+            # instead of slowing to tens of seconds until autovacuum catches up.
+            opdsdb.vacuum_analyze()
         finally:
             self.scan_is_active = False
-            self._release_lock(lock_fd)
+            release_lock()
         
     def update_shedule(self):
         self.SCAN_SHED_DAY = config.SOPDS_SCAN_SHED_DAY

--- a/opds_catalog/migrations/0017_scanseen.py
+++ b/opds_catalog/migrations/0017_scanseen.py
@@ -1,0 +1,23 @@
+# Scratch table for the incremental-scan "seen book ids" set. Replaces the old
+# full-table `UPDATE opds_catalog_book SET avail=1` sweep at the start of every
+# scan (which rewrote every row -> bloat + slow reads during a scan).
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("opds_catalog", "0016_book_lang_search_title_index"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="ScanSeen",
+            fields=[
+                ("book_id", models.BigIntegerField(primary_key=True, serialize=False)),
+            ],
+            options={
+                "db_table": "opds_catalog_scan_seen",
+            },
+        ),
+    ]

--- a/opds_catalog/models.py
+++ b/opds_catalog/models.py
@@ -173,3 +173,19 @@ class Counter(models.Model):
     update_time = models.DateTimeField(null=False, default=timezone.now)
     obj = models.Manager()
     objects = CounterManager()
+
+
+class ScanSeen(models.Model):
+    """Scratch list of book ids seen during the current library scan.
+
+    Replaces the old full-table `avail=1` flip: the scanner records here each
+    book it re-finds or adds, and the post-walk sweep deletes the books NOT
+    listed (anti-join). It is a plain id column, not a ForeignKey, so recording
+    an id is cheap and never rewrites the (large) Book table; rows are cleared
+    at the start of every scan. Access is serialized by the scanner's advisory
+    lock, so a single shared table is safe.
+    """
+    book_id = models.BigIntegerField(primary_key=True)
+
+    class Meta:
+        db_table = 'opds_catalog_scan_seen'

--- a/opds_catalog/opdsdb.py
+++ b/opds_catalog/opdsdb.py
@@ -3,11 +3,10 @@
 import os
 import re
 
-from django.db.models import Q
 from django.utils.translation import gettext as _ , gettext_noop as _noop
 from django.db import transaction, connection
 
-from opds_catalog.models import Book, Catalog, Author, Genre, Series, bseries, bauthor, bgenre, LangCodes
+from opds_catalog.models import Book, Catalog, Author, Genre, Series, bseries, bauthor, bgenre, LangCodes, ScanSeen
 from opds_catalog.models import SIZE_BOOK_FILENAME, SIZE_BOOK_PATH, SIZE_BOOK_FORMAT, SIZE_BOOK_DOCDATE, SIZE_BOOK_LANG, SIZE_BOOK_TITLE, SIZE_BOOK_ANNOTATION
 from opds_catalog.models import SIZE_CAT_CATNAME, SIZE_CAT_PATH, SIZE_AUTHOR_NAME, SIZE_GENRE, SIZE_GENRE_SUBSECTION, SIZE_SERIES
 
@@ -89,15 +88,78 @@ def clear_genres(verbose=False):
     cursor = connection.cursor()
     cursor.execute('delete from opds_catalog_genre')
 
-# Книги где avail=0 уже известно что удалены
-# Книги где avail=2 это только что прверенные существующие книги
-# Устанавливаем avail=1 для книг которые не удалены. Во время проверки
-# если они не удалены им присвоится значение 2
-# Книги с avail=0 проверятся не будут и будут убраны из всех выдач и всех обработок.
+# Incremental-scan bookkeeping.
 #
-# три позиции (0,1,2) сделаны для того чтобы сделать возможным корректную работу
-# cgi-скрипта во время сканирования библиотеки
+# Old scheme: flip every non-deleted book to avail=1 up front, mark the ones
+# re-found during the walk back to avail=2, then delete everything left at
+# avail<=1. That start-of-scan `UPDATE opds_catalog_book SET avail=1` rewrote
+# the whole table on every scan (bloat + slow reads while scanning, and it was
+# the query that got orphaned and ran for hours).
 #
+# New scheme: don't touch the Book table up front at all. Record the id of each
+# book re-found or added into the scratch `ScanSeen` table (see mark_seen /
+# _mark_seen_qs), then delete the books NOT recorded (scan_finish, an anti-join
+# that only touches the actually-vanished rows). `avail` is kept only for the
+# logical-delete mode (avail=0) and is not read by the OPDS/web output.
+
+SEEN_BATCH = 5000
+
+
+def scan_begin():
+    """Start a scan pass: clear the scratch table of seen book ids.
+
+    Replaces avail_check_prepare()'s full-table `UPDATE avail=1` — nothing on
+    opds_catalog_book is written, so unchanged books are never rewritten.
+    """
+    ScanSeen.objects.all().delete()
+
+
+def mark_seen(book_id):
+    """Record a single book id as present in this scan pass."""
+    ScanSeen.objects.bulk_create([ScanSeen(book_id=book_id)], ignore_conflicts=True)
+
+
+def _mark_seen_qs(book_qs):
+    """Record every book matched by `book_qs` as seen; return how many.
+
+    Used by the archive skip fast-paths: an unchanged archive's books are all
+    still present, so mark them without re-reading the archive.
+    """
+    ids = list(book_qs.values_list('id', flat=True))
+    if ids:
+        ScanSeen.objects.bulk_create(
+            (ScanSeen(book_id=i) for i in ids), ignore_conflicts=True, batch_size=SEEN_BATCH)
+    return len(ids)
+
+
+def scan_finish(logical=False):
+    """Remove books not seen during this scan (anti-join on ScanSeen).
+
+    Physical delete relies on the ORM to cascade the m2m/bookshelf rows; the
+    logical mode just marks them avail=0. Deletes in id chunks so a large
+    delete set can't blow the SQL parameter limit.
+
+    Safety: if nothing was recorded as seen while the catalogue is non-empty,
+    refuse to delete — a real scan of a non-empty library always sees at least
+    one book, so an empty seen set means the scan didn't run (never wipe the
+    whole catalogue).
+    """
+    if ScanSeen.objects.count() == 0 and Book.objects.exists():
+        return 0
+
+    gone_ids = list(Book.objects.exclude(id__in=ScanSeen.objects.values('book_id'))
+                    .values_list('id', flat=True))
+    if not gone_ids:
+        return 0
+
+    for start in range(0, len(gone_ids), SEEN_BATCH):
+        chunk = gone_ids[start:start + SEEN_BATCH]
+        if logical:
+            Book.objects.filter(id__in=chunk).update(avail=0)
+        else:
+            Book.objects.filter(id__in=chunk).delete()
+    return len(gone_ids)
+
 
 def p(s,size):
     new = utfhigh.sub(u'',s[:size])
@@ -113,49 +175,32 @@ def getlangcode(s):
     
     return langcode
     
-def avail_check_prepare():
-    Book.objects.filter(~Q(avail=0)).update(avail=1)
-
-def books_del_logical():
-    row_count = Book.objects.filter(avail=1).update(avail=0)
-    return row_count
-
-def books_del_phisical():
-    # delete() returns (total, {label: n}); surface the integer count so the
-    # scanner's "deleted" stat/log is a number, consistent with books_del_logical.
-    row_count, _ = Book.objects.filter(avail__lte=1).delete()
-    # TODO: Разобратся нужно ли удалять записи в таблицах связи ManyToMany или они сами удалятся?
-    # sql='delete from '+TBL_BAUTHORS+' where book_id in (select book_id from '+TBL_BOOKS+' where avail<=1)'
-    # sql='delete from '+TBL_BGENRES+' where book_id in (select book_id from '+TBL_BOOKS+' where avail<=1)'
-    return row_count
-
 def arc_skip(arcpath,arcsize):
     """
        Выясняем изменялся ли архив (ZIP или INP-файл)
-       если нет, то пытаемся пропустить сканирование, устанавливая для всех книг из
-       архива avail=2
+       если нет, то пытаемся пропустить сканирование, помечая все книги из
+       архива как увиденные (seen)
        Если не одной такой книги не нашлось, то считаем что пропуск сканирования не удался
        и возвращаем 0
-       Если книги из искомого каталога имелись и для них установлен avail=2, то пропуск возможен 
-       и возвращаем 1 (или row_count)      
+       Если книги из искомого каталога имелись и помечены seen, то пропуск возможен
+       и возвращаем 1 (или row_count)
     """
     catalog = findcat(arcpath)
-    
+
     # Если такого каталога еще нет в БД, то значит считаем что ZIP изменен и пропуск невозможен
     if catalog == None:
         return 0
-    
+
     # Если каталог в БД найден и его размер совпадает с текущим, то считаем что файл архива не менялся
-    # Поэтому делаем update всех книг из этого архива, однако если ни одного изменения не произошло, то
-    # таких книг нет, поэтому видимо нужно пересканировать архив
+    # Поэтому помечаем все книги из этого архива как увиденные; если таких книг нет,
+    # то видимо нужно пересканировать архив
     if arcsize == catalog.cat_size:
-        row_count = Book.objects.filter(path=arcpath).update(avail=2)
-        return row_count 
-    
-    # Здесь мы оказываемся если размеры архива в БД и в наличии разные, поэтому считаем что изменения в архиве есть 
-    # и пропуск сканирования невозможен    
+        return _mark_seen_qs(Book.objects.filter(path=arcpath))
+
+    # Здесь мы оказываемся если размеры архива в БД и в наличии разные, поэтому считаем что изменения в архиве есть
+    # и пропуск сканирования невозможен
     return 0
-    
+
 
 def inp_skip(arcpath,arcsize):
     """
@@ -177,11 +222,10 @@ def inp_skip(arcpath,arcsize):
     # Поэтому делаем update всех книг из этого INPX, однако если ни одного изменения не произошло, то
     # таких книг нет, поэтому видимо нужно пересканировать архив
     if arcsize == catalog.cat_size:
-        row_count = Book.objects.filter(catalog__parent=catalog).update(avail=2)
-        return row_count     
-    
-    # Здесь мы оказываемся если размеры INPX в БД и в наличии разные, поэтому считаем что изменения в архиве есть 
-    # и пропуск сканирования невозможен        
+        return _mark_seen_qs(Book.objects.filter(catalog__parent=catalog))
+
+    # Здесь мы оказываемся если размеры INPX в БД и в наличии разные, поэтому считаем что изменения в архиве есть
+    # и пропуск сканирования невозможен
     return 0
 
 
@@ -205,10 +249,9 @@ def inpx_skip(arcpath, arcsize):
     # Поэтому делаем update всех книг из этого INPX, однако если ни одного изменения не произошло, то
     # таких книг нет, поэтому видимо нужно пересканировать архив
     if arcsize == catalog.cat_size:
-        row_count = Book.objects.filter(catalog__parent__parent=catalog).update(avail=2)
-        return row_count
+        return _mark_seen_qs(Book.objects.filter(catalog__parent__parent=catalog))
 
-        # Здесь мы оказываемся если размеры INPX в БД и в наличии разные, поэтому считаем что изменения в архиве есть
+    # Здесь мы оказываемся если размеры INPX в БД и в наличии разные, поэтому считаем что изменения в архиве есть
     # и пропуск сканирования невозможен
     return 0
 
@@ -241,9 +284,11 @@ def findbook(name, path, setavail=0):
     # the scan.
     book = Book.objects.filter(filename=name[:SIZE_BOOK_FILENAME], path=path[:SIZE_BOOK_PATH]).first()
 
+    # `setavail` keeps its old meaning "this book is present in the current
+    # scan": record it as seen (no write to the Book row) instead of the old
+    # book.avail=2; book.save().
     if book and setavail:
-        book.avail=2
-        book.save()
+        mark_seen(book.id)
 
     return book
 
@@ -251,6 +296,8 @@ def addbook(name, path, cat, exten, title, annotation, docdate, lang, size=0, ar
     book = Book.objects.create(filename=name[:SIZE_BOOK_FILENAME],path=path[:SIZE_BOOK_PATH],catalog=cat,filesize=size,format=exten.lower()[:SIZE_BOOK_FORMAT],
                 title=title[:SIZE_BOOK_TITLE],search_title=title.upper()[:SIZE_BOOK_TITLE],annotation=p(annotation,SIZE_BOOK_ANNOTATION),
                 docdate=docdate[:SIZE_BOOK_DOCDATE],lang=lang[:SIZE_BOOK_LANG],cat_type=archive,avail=2, lang_code=getlangcode(title))
+    # A freshly added book is present in this scan.
+    mark_seen(book.id)
     return book
 
 def addauthor(full_name):

--- a/opds_catalog/opdsdb.py
+++ b/opds_catalog/opdsdb.py
@@ -54,6 +54,24 @@ def pg_optimize(verbose=False):
         cursor.execute('VACUUM FULL opds_catalog_book')
         print('PostgreSql tables internal structure optimized...')
 
+def vacuum_analyze(verbose=False):
+    """VACUUM ANALYZE the large catalog tables (PostgreSQL only).
+
+    Run after a scan: the full-table ``avail`` sweep churns every row, so
+    without this the tables accumulate dead tuples and a stale visibility map
+    until autovacuum catches up, during which the alphabet menu loses its
+    Index-Only Scan and slows to tens of seconds. VACUUM (not FULL) is
+    non-blocking. Safe to skip on non-PostgreSQL backends.
+    """
+    if connection.vendor != 'postgresql':
+        return
+    with connection.cursor() as cursor:
+        for table in ('opds_catalog_book', 'opds_catalog_author', 'opds_catalog_series'):
+            if verbose:
+                print('VACUUM (ANALYZE) %s ...' % table)
+            cursor.execute('VACUUM (ANALYZE) %s' % table)
+
+
 def clear_all(verbose=False):
     cursor = connection.cursor()
     cursor.execute('delete from opds_catalog_bseries')

--- a/opds_catalog/sopdscan.py
+++ b/opds_catalog/sopdscan.py
@@ -84,7 +84,7 @@ class opdsScanner:
         self.zip_file = None
         self.rel_path = None     
                     
-        opdsdb.avail_check_prepare()
+        opdsdb.scan_begin()
             
         # followlinks=True is kept so symlinked book directories are scanned,
         # but a symlink cycle would otherwise recurse forever (os.walk docs).
@@ -121,15 +121,11 @@ class opdsScanner:
                         file_size=os.path.getsize(file)
                         self.processfile(name,full_path,file,None,0,file_size)
 
-        #if config.SOPDS_DELETE_LOGICAL:
-        #    self.books_deleted=opdsdb.books_del_logical()
-        #else:
-        #    self.books_deleted=opdsdb.books_del_phisical()
-            
-        # Keep the delete-sweep atomic on its own: it removes every book not
-        # re-marked avail=2 by this scan, and must be all-or-nothing.
+        # Delete-sweep: remove (or, in logical mode, mark avail=0) every book
+        # not recorded as seen during this scan. Kept atomic on its own, and
+        # guarded against wiping the catalogue on an empty seen set.
         with transaction.atomic():
-            self.books_deleted=opdsdb.books_del_phisical()
+            self.books_deleted = opdsdb.scan_finish(logical=config.SOPDS_DELETE_LOGICAL)
 
         self.log_stats()
 

--- a/opds_catalog/tests/test_scan_lock.py
+++ b/opds_catalog/tests/test_scan_lock.py
@@ -24,3 +24,19 @@ def test_scan_lock_is_exclusive(tmp_path):
     fd3 = cmd._acquire_lock()      # released -> available again
     assert fd3 is not None
     cmd._release_lock(fd3)
+
+
+def test_acquire_scan_lock_is_exclusive(tmp_path):
+    # The vendor dispatch: on sqlite (tests) it falls back to the flock and
+    # returns a release callable; a second acquisition is refused until release.
+    cmd = Command()
+    cmd.pidfile = str(tmp_path / 's.pid')
+
+    release = cmd._acquire_scan_lock()
+    assert callable(release)
+    assert cmd._acquire_scan_lock() is None   # held
+
+    release()
+    release2 = cmd._acquire_scan_lock()       # available again
+    assert callable(release2)
+    release2()

--- a/opds_catalog/tests/test_scan_seen.py
+++ b/opds_catalog/tests/test_scan_seen.py
@@ -1,0 +1,81 @@
+"""Incremental-scan `avail` redesign: the seen-set sweep (opdsdb.scan_*).
+
+A book that vanished from disk is deleted on the next scan; an empty seen set
+never wipes the catalogue; logical mode marks avail=0 instead of deleting.
+"""
+import os
+import shutil
+
+import pytest
+from constance import config
+
+from opds_catalog import opdsdb
+from opds_catalog.sopdscan import opdsScanner
+from opds_catalog.models import Book
+
+DATA = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
+
+
+def _addbook(name):
+    cat = opdsdb.addcattree('.')
+    return opdsdb.addbook(name, '.', cat, 'fb2', 'T ' + name, '', '2020', 'en', 1, 0)
+
+
+@pytest.mark.django_db
+def test_rescan_deletes_a_book_removed_from_disk(tmp_path):
+    lib = tmp_path / 'lib'
+    lib.mkdir()
+    shutil.copy(os.path.join(DATA, '262001.fb2'), lib / 'a.fb2')
+    shutil.copy(os.path.join(DATA, '262001.fb2'), lib / 'b.fb2')
+
+    config.SOPDS_ROOT_LIB = str(lib)
+    config.SOPDS_INPX_ENABLE = False
+    config.SOPDS_DELETE_LOGICAL = False
+    opdsdb.clear_all()
+
+    opdsScanner().scan_all()
+    assert Book.objects.count() == 2
+
+    (lib / 'b.fb2').unlink()          # book vanished from disk
+    scanner = opdsScanner()
+    scanner.scan_all()
+
+    assert Book.objects.count() == 1
+    assert Book.objects.filter(filename='a.fb2').exists()
+    assert not Book.objects.filter(filename='b.fb2').exists()
+    assert scanner.books_deleted == 1
+
+
+@pytest.mark.django_db
+def test_scan_finish_empty_seen_does_not_wipe_catalogue():
+    opdsdb.clear_all()
+    _addbook('x.fb2')                 # creates the book AND marks it seen
+    opdsdb.scan_begin()               # clear the seen set
+
+    deleted = opdsdb.scan_finish()    # seen empty + catalogue non-empty -> guard
+    assert deleted == 0
+    assert Book.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_scan_finish_physical_and_logical():
+    opdsdb.clear_all()
+    b1 = _addbook('a.fb2')
+    b2 = _addbook('b.fb2')
+
+    # Only b1 is seen this pass.
+    opdsdb.scan_begin()
+    opdsdb.mark_seen(b1.id)
+
+    # Logical: b2 marked avail=0, not deleted.
+    assert opdsdb.scan_finish(logical=True) == 1
+    assert Book.objects.count() == 2
+    b2.refresh_from_db(); assert b2.avail == 0
+    b1.refresh_from_db(); assert b1.avail == 2
+
+    # Physical: b2 removed.
+    opdsdb.scan_begin()
+    opdsdb.mark_seen(b1.id)
+    assert opdsdb.scan_finish(logical=False) == 1
+    assert Book.objects.count() == 1
+    assert Book.objects.filter(id=b1.id).exists()

--- a/opds_catalog/tests/test_vacuum_analyze.py
+++ b/opds_catalog/tests/test_vacuum_analyze.py
@@ -1,0 +1,10 @@
+"""opdsdb.vacuum_analyze() is a safe no-op on non-PostgreSQL backends."""
+import pytest
+
+from opds_catalog import opdsdb
+
+
+@pytest.mark.django_db
+def test_vacuum_analyze_noop_on_sqlite():
+    # The test DB is sqlite; vacuum_analyze must return without raising.
+    opdsdb.vacuum_analyze()


### PR DESCRIPTION
## Summary

Removes the root cause of the incident: every library scan rewrote the entire
`Book` table up front.

**Old scheme (3-state `avail`):** `avail_check_prepare()` ran
`UPDATE opds_catalog_book SET avail=1` over every non-deleted row, the walk
marked re-found books back to `avail=2`, then `avail<=1` rows were deleted. On a
699k-row / 1.9 GB table that full-table UPDATE churned every row on every scan
(bloat + degraded reads during a scan) — and it is exactly the statement that
was orphaned by a pod restart and ran for ~2h, slowing `/web/book`.

**New scheme (seen-set anti-join):** nothing on `Book` is written up front.

- `scan_begin()` clears a scratch `ScanSeen` table (migration `0017`).
- `findbook()` (re-found) and `addbook()` (new) record the book id as seen;
  the archive skip fast-paths (`arc_skip`/`inp_skip`/`inpx_skip`) bulk-record
  a whole unchanged archive's ids.
- `scan_finish()` deletes the books **not** recorded (anti-join, in id chunks,
  ORM cascade), or marks them `avail=0` in logical mode.

Unchanged books are never rewritten → no bloat and no read slowdown while
scanning. `avail` is kept only for logical-delete/admin and is **not** read by
the OPDS/web output (verified: no `avail` filter anywhere in the read path).

## Safety

- `scan_finish()` **refuses to delete** when the seen set is empty while the
  catalogue is non-empty — a real scan of a non-empty library always sees at
  least one book, so an empty seen set means the scan didn't run. This makes
  the "wipe the whole catalogue" failure mode impossible.
- `ScanSeen` is a real table (survives connection blips), written inside the
  same per-directory transactions as the books, so a rolled-back directory
  rolls back its seen marks too (same consistency as the old `avail`).

## Tests

- vanished-from-disk book is deleted on re-scan
- empty seen set never wipes the catalogue (guard)
- physical vs logical (`avail=0`) delete
- existing scan / incremental-scan / counts suites still green (169 pass), `ruff`
  clean, `makemigrations --check` clean.

## Stacking

Stacked on **fix/scan-locking (#55)** → base branch is `fix/scan-locking`.
Retarget to `master` as the earlier PRs merge (`fix/deep-review` #54 →
`fix/scan-locking` #55 → this).

## Note

Per-book `mark_seen()` is one INSERT per loose file (parity with the old
per-book `save()`), no `Book` churn; archive skips are bulk. Batching the
per-book inserts is a possible follow-up if a huge loose-file tree ever needs it.
