### PR TITLE
Review follow-ups: mask secrets, narrow bare excepts, cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ All notable changes to this project are documented here. The format is based on
   uses `-c`), so the test environment never drifts from production.
 
 ### Fixed
+- **Security:** the OIDC client secret and Telegram API token are entered
+  through a masked password field in the constance admin instead of being
+  shown in clear text.
+- Narrowed bare `except:` clauses to `except Exception:` in the download views
+  and the FB2/EPUB parsers, so `KeyboardInterrupt`/`SystemExit` propagate
+  instead of being swallowed.
+- Removed the empty, unused `opds_catalog/views.py`.
 - **Security:** open redirect in `LoginView` (`?next=` is now validated with
   `url_has_allowed_host_and_scheme`).
 - Hardened the book-conversion route: `convert_type` restricted to `epub|mobi`

--- a/book_tools/format/__init__.py
+++ b/book_tools/format/__init__.py
@@ -96,7 +96,7 @@ def detect_mime(file, original_filename):
             sniffed = __sniff_content(file)
             if sniffed is not None:
                 return sniffed
-    except:
+    except Exception:
         pass
 
     return mime

--- a/book_tools/format/epub.py
+++ b/book_tools/format/epub.py
@@ -89,7 +89,7 @@ class EPub(BookFile):
         with self.__zip_file.open(info) as entry:
             try:
                 return etree.fromstring(entry.read(1048576), parser=safe_lxml_parser())
-            except:
+            except Exception:
                 raise EPub.StructureException('\'' + info.filename + '\' is not a valid XML')
 
     def __extract_metainfo(self):
@@ -155,7 +155,7 @@ class EPub(BookFile):
             path = os.path.normpath(prefix + node.get('href')).replace('\\','/')
             try:
                 fileinfo = self.__zip_file.getinfo(path)
-            except:
+            except Exception:
                 fileinfo = self.__zip_file.getinfo(urllib.parse.unquote(path))
             mime = node.get('media-type')
             info = {
@@ -225,7 +225,7 @@ class EPub(BookFile):
     def __get_root_info(self):
         try:
             container_info = self.__zip_file.getinfo(EPub.Entry.CONTAINER)
-        except:
+        except Exception:
             container_info = None
         if container_info:
             tree = self.__etree_from_entry(container_info)
@@ -266,7 +266,7 @@ class EPub(BookFile):
                 key_name = res[0].text
                 if key_name and key_name.startswith(EPub.CONTENT_ID_PREFIX):
                     content_ids.add(key_name[len(EPub.CONTENT_ID_PREFIX):])
-        except:
+        except Exception:
             pass
         return list(content_ids)
 
@@ -289,7 +289,7 @@ class EPub(BookFile):
                     algo = algorithms[0]
                 else:
                     return UNKNOWN_ENCRYPTION
-            except:
+            except Exception:
                 return UNKNOWN_ENCRYPTION
 
         if self.__contains_entry(EPub.Entry.RIGHTS):
@@ -306,7 +306,7 @@ class EPub(BookFile):
                             'token_url': token_url,
                             'content_ids': content_ids
                         }
-                except:
+                except Exception:
                     pass
             return UNKNOWN_ENCRYPTION
 

--- a/book_tools/format/fb2.py
+++ b/book_tools/format/fb2.py
@@ -52,7 +52,7 @@ class FB2Base(BookFile):
             with open(os.path.join(working_dir, 'cover.jpeg'), 'wb') as cover_file:
                 cover_file.write(content)
             return ('cover.jpeg', False)
-        except:
+        except Exception:
             return (None, False)
 
     def extract_cover_memory(self):
@@ -201,7 +201,7 @@ class FB2Zip(FB2Base):
         with self.__zip_file.open(self.__infos[0]) as entry:
             try:
                 return etree.fromstring(entry.read(50 * 1024 * 1024), parser=safe_lxml_parser())
-            except:
+            except Exception:
                 raise FB2StructureException('\'%s\' is not a valid XML' % self.__infos[0].filename)
 
     def __exit__(self, kind, value, traceback):

--- a/opds_catalog/dl.py
+++ b/opds_catalog/dl.py
@@ -283,7 +283,7 @@ def Cover(request, book_id, thumbnail=False):
             fo.close()
             z.close()
             fz.close()
-    except:
+    except Exception:
         book_data = None
         image = None
 
@@ -362,7 +362,7 @@ def Cover0(request, book_id, thumbnail = False):
                     response["Content-Type"] = fb2.cover_image.getattr('content-type')
                 response.write(dstr)
                 c0=1
-            except:
+            except Exception:
                 c0=0
 
     if c0==0:
@@ -456,11 +456,11 @@ def ConvertFB2(request, book_id, convert_type):
     try: 
         if tmp_fb2_path:
             os.remove(tmp_fb2_path)
-    except: 
+    except Exception: 
         pass
     try: 
         os.remove(tmp_conv_path)
-    except: 
+    except Exception: 
         pass
 
     return response

--- a/sopds/settings.py
+++ b/sopds/settings.py
@@ -246,6 +246,14 @@ CONSTANCE_ADDITIONAL_FIELDS = {
         'widget': 'django.forms.Select',
         'choices': (("ru-RU", "Russian"), ("en-US", "English"))
     }],
+    # Masked input for secrets (OIDC client secret, Telegram token) so they are
+    # not shown in clear text on the constance admin page. render_value keeps the
+    # stored value on save; required=False allows clearing it.
+    'password_input': ['django.forms.fields.CharField', {
+        'widget': 'django.forms.PasswordInput',
+        'widget_kwargs': {'render_value': True},
+        'required': False,
+    }],
 }
 
 CONSTANCE_CONFIG = OrderedDict([
@@ -255,7 +263,7 @@ CONSTANCE_CONFIG = OrderedDict([
     ('SOPDS_SCAN_START_DIRECTLY', (False,_('Turn once scanning directly'))),
     ('SOPDS_CACHE_TIME', (1200, _('Pages cache time'))),
 
-    ('SOPDS_TELEBOT_API_TOKEN', ('', _('Telegramm API Token'))),
+    ('SOPDS_TELEBOT_API_TOKEN', ('', _('Telegramm API Token'), 'password_input')),
     ('SOPDS_TELEBOT_AUTH', (True,_('Enable telebot authentication. Test presense telegram username in local users database (case insensetive).'))),
     ('SOPDS_TELEBOT_MAXITEMS', (10, _('Max items on page'))),
     
@@ -297,7 +305,7 @@ CONSTANCE_CONFIG = OrderedDict([
     ('SOPDS_OIDC_ENABLE', (False, _('Enable OIDC (Keycloak) login on the web login page'))),
     ('SOPDS_OIDC_ISSUER', ('', _('OIDC issuer URL (Keycloak realm), e.g. https://keycloak.example.com/realms/library'))),
     ('SOPDS_OIDC_CLIENT_ID', ('', _('OIDC client ID'))),
-    ('SOPDS_OIDC_CLIENT_SECRET', ('', _('OIDC client secret'))),
+    ('SOPDS_OIDC_CLIENT_SECRET', ('', _('OIDC client secret'), 'password_input')),
     ('SOPDS_OIDC_SCOPES', ('openid email profile', _('OIDC scopes (space-separated)'))),
     ('SOPDS_OIDC_BUTTON_TEXT', ('Log in with Keycloak', _('Text on the OIDC login button'))),
 

--- a/sopds_web_backend/tests/test_search_by_id.py
+++ b/sopds_web_backend/tests/test_search_by_id.py
@@ -1,0 +1,26 @@
+"""search-by-id (`searchtype=i`) must degrade gracefully for a missing id.
+
+Regression guard for the old `books[0].title` IndexError -> 500: an unknown
+book id now renders an empty result page (HTTP 200), not a 500.
+"""
+import pytest
+from django.urls import reverse
+
+
+@pytest.fixture
+def logged_client(client, django_user_model):
+    user = django_user_model.objects.create_user("sid", "s@x.y", "pw")
+    client.force_login(user)
+    return client
+
+
+@pytest.mark.django_db
+def test_search_by_id_missing_book_renders_200(logged_client):
+    resp = logged_client.get(reverse("web:searchbooks"), {"searchtype": "i", "searchterms": 999999})
+    assert resp.status_code == 200
+
+
+@pytest.mark.django_db
+def test_search_by_id_non_numeric_renders_200(logged_client):
+    resp = logged_client.get(reverse("web:searchbooks"), {"searchtype": "i", "searchterms": "abc"})
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary

Follow-ups from the deep-review low/nit checklist (#52) and a test-coverage gap
(#51), independent of the scanner stack (#55/#56).

- **Secrets masked in admin** — `SOPDS_OIDC_CLIENT_SECRET` and
  `SOPDS_TELEBOT_API_TOKEN` now use a `PasswordInput` (constance
  `password_input` field, `render_value=True`) instead of a clear-text box.
- **Bare `except:` narrowed to `except Exception:`** in `dl.py` and the FB2/EPUB
  parsers so `KeyboardInterrupt`/`SystemExit` propagate (PEP 8, CWE-396).
- **Removed** the empty, unused `opds_catalog/views.py`.
- **Test** — search-by-id (`searchtype=i`) with a missing/non-numeric id renders
  200, not 500 (regression guard; the branch is master's #34 try/except fix).

166 tests pass; `ruff` clean.

## Remaining #52 items (deliberately not here)

Left for follow-ups, mostly because they need a migration or touch files in the
open scanner stack (#55/#56):

- `search_*` fields `default=None` without `null=True` (needs a migration;
  would collide with #56's migration `0017`)
- `del(connections._connections.default)` in `check_settings` (touched by #55)
- `cache_page(config...)` import-time binding in `dl.py`
- MySQL `utf8_general_ci` → `utf8mb4` (DB migration)
- dead Py2 HUFF/CDIC branch in vendored `pymobi`
