### PR TITLE
Search suggestions: show the first author next to the title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project are documented here. The format is based on
 ### Added
 - htmx live-search suggestions in the header search box (title/author/series),
   as progressive enhancement.
+- Title suggestions now show the book's first author next to the title, so
+  same-/similar-titled books are distinguishable.
 - pytest / pytest-django test suite with coverage; GitHub Actions CI running
   the suite on Python 3.12, plus a non-blocking `ruff` lint pass.
 - Tooling config in `pyproject.toml` (ruff, mypy); `CONTRIBUTING.md`.

--- a/sopds_web_backend/tests/test_search_suggest.py
+++ b/sopds_web_backend/tests/test_search_suggest.py
@@ -37,6 +37,23 @@ def test_suggest_titles(logged_client):
 
 
 @pytest.mark.django_db
+def test_suggest_titles_show_first_author(logged_client):
+    from opds_catalog.models import bauthor
+    b1 = _make_book("Book One")
+    tolstoy = Author.objects.create(full_name="Leo Tolstoy", search_full_name="LEO TOLSTOY")
+    bauthor.objects.create(book=b1, author=tolstoy)
+    _make_book("Book Two")   # no author
+
+    resp = logged_client.post(
+        reverse("web:suggest"), {"searchterms": "book", "suggesttype": "title"}
+    )
+    body = resp.content.decode()
+    assert "Book One — Leo Tolstoy" in body   # title + first author
+    assert "Book Two" in body                  # authorless book still listed...
+    assert "Book Two —" not in body            # ...with no dangling separator
+
+
+@pytest.mark.django_db
 def test_suggest_authors(logged_client):
     Author.objects.create(full_name="Leo Tolstoy", search_full_name="LEO TOLSTOY")
     Author.objects.create(full_name="Mark Twain", search_full_name="MARK TWAIN")

--- a/sopds_web_backend/views.py
+++ b/sopds_web_backend/views.py
@@ -823,8 +823,13 @@ def SearchSuggestView(request):
             for s in Series.objects.filter(search_ser__contains=up)[:10]:
                 suggestions.append({'label': s.ser, 'url': '%s?searchtype=s&searchterms=%d' % (base, s.id)})
         else:
-            for b in Book.objects.filter(search_title__contains=up)[:10]:
-                suggestions.append({'label': b.title, 'url': '%s?searchtype=i&searchterms=%d' % (base, b.id)})
+            # Show the first author next to the title so books with the same or
+            # similar title are distinguishable. prefetch_related avoids an extra
+            # query per suggestion.
+            for b in Book.objects.filter(search_title__contains=up).prefetch_related('authors')[:10]:
+                authors = list(b.authors.all())
+                label = '%s — %s' % (b.title, authors[0].full_name) if authors else b.title
+                suggestions.append({'label': label, 'url': '%s?searchtype=i&searchterms=%d' % (base, b.id)})
     return render(request, 'sopds_search_suggestions.html', {'suggestions': suggestions})
 
 


### PR DESCRIPTION
Fixes #58.

The htmx title-autocomplete showed only the book title, so books with the same
or similar title were indistinguishable. Title suggestions now render
`<title> — <first author>`; an authorless book keeps just the title (no
dangling separator). `prefetch_related('authors')` avoids a per-suggestion
query for the ≤10 rows.

Author- and series-suggestion branches are unchanged. Test added; 172 pass,
ruff clean.