### PR TITLE
Add sopds_isbn_backfill command for existing catalogue entries

### DIFF
--- a/opds_catalog/management/commands/sopds_isbn_backfill.py
+++ b/opds_catalog/management/commands/sopds_isbn_backfill.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+#
+# Backfill Book.isbn for books already in the catalogue.
+#
+# A normal (incremental) scan skips books already present in the DB, so the
+# isbn column added in migration 0019 stays empty for the existing catalogue.
+# This command re-reads each such book's file from disk, extracts the ISBN with
+# the same parsers the scanner uses, and updates only the isbn field — without a
+# full re-scan (registerdate, authors, genres and series are left untouched).
+#
+# Only fb2/epub are considered: those are the formats the parsers extract an
+# ISBN from. Run: python manage.py sopds_isbn_backfill [--dry-run] [--limit N]
+import logging
+
+from django.core.management.base import BaseCommand
+from django.db import close_old_connections
+
+from opds_catalog import dl
+from opds_catalog.models import Book, SIZE_BOOK_ISBN
+from book_tools.format import create_bookfile
+
+# Formats whose metadata the parsers read an ISBN from.
+ISBN_FORMATS = ['fb2', 'epub']
+
+
+class Command(BaseCommand):
+    help = 'Backfill Book.isbn from book files for catalogue entries missing it.'
+
+    def add_arguments(self, parser):
+        parser.add_argument('--dry-run', action='store_true', default=False,
+                            help='Report what would change without writing to the DB.')
+        parser.add_argument('--limit', type=int, default=0,
+                            help='Process at most N books (0 = all).')
+        parser.add_argument('--verbose', action='store_true', default=False,
+                            help='Log every updated book.')
+
+    def handle(self, *args, **options):
+        dry_run = options['dry_run']
+        limit = options['limit']
+        verbose = options['verbose']
+        logger = logging.getLogger('')
+
+        close_old_connections()
+        qs = Book.objects.filter(isbn='', format__in=ISBN_FORMATS).order_by('id')
+
+        scanned = updated = no_isbn = missing = errors = 0
+        for book in qs.iterator(chunk_size=500):
+            if limit and scanned >= limit:
+                break
+            scanned += 1
+
+            data = dl.getFileData(book)
+            if data is None:
+                missing += 1
+                continue
+
+            try:
+                book_data = create_bookfile(data, book.filename)
+            except Exception as err:
+                errors += 1
+                logger.debug('ISBN backfill parse error for book %s: %s', book.id, err)
+                continue
+
+            isbn = (getattr(book_data, 'isbn', '') or '')[:SIZE_BOOK_ISBN]
+            if not isbn:
+                no_isbn += 1
+                continue
+
+            updated += 1
+            if verbose:
+                self.stdout.write('Book %s (%s): ISBN %s' % (book.id, book.filename, isbn))
+            if not dry_run:
+                Book.objects.filter(pk=book.pk).update(isbn=isbn)
+
+        prefix = 'DRY-RUN: ' if dry_run else ''
+        self.stdout.write(
+            '%sISBN backfill done. Scanned: %d, %s: %d, no ISBN: %d, file missing: %d, parse errors: %d'
+            % (prefix, scanned, 'would update' if dry_run else 'updated', updated, no_isbn, missing, errors)
+        )

--- a/opds_catalog/tests/test_isbn_backfill.py
+++ b/opds_catalog/tests/test_isbn_backfill.py
@@ -1,0 +1,75 @@
+"""Coverage for the sopds_isbn_backfill management command."""
+import pytest
+from django.core.management import call_command
+
+from constance import config
+
+from opds_catalog import opdsdb
+from opds_catalog.models import Book, Catalog
+
+FB2 = (
+    '<?xml version="1.0" encoding="utf-8"?>'
+    '<FictionBook xmlns="http://www.gribuser.ru/xml/fictionbook/2.0">'
+    '<description>'
+    '<title-info><book-title>T</book-title>'
+    '<author><last-name>A</last-name><first-name>B</first-name></author>'
+    '<lang>ru</lang></title-info>'
+    '<publish-info>{isbn}</publish-info>'
+    '</description>'
+    '<body><section><p>x</p></section></body></FictionBook>'
+)
+
+
+def _book(tmp_path, name, isbn_xml, fmt='fb2'):
+    (tmp_path / name).write_bytes(FB2.format(isbn=isbn_xml).encode('utf-8'))
+    cat = Catalog.objects.create(cat_name='.', path='.', cat_type=0)
+    return Book.objects.create(filename=name, path='.', catalog=cat, format=fmt,
+                               title='T', search_title='T', annotation='',
+                               docdate='', lang='ru', cat_type=opdsdb.CAT_NORMAL,
+                               avail=2, isbn='')
+
+
+@pytest.mark.django_db
+def test_backfill_populates_isbn(tmp_path):
+    config.SOPDS_ROOT_LIB = str(tmp_path)
+    book = _book(tmp_path, 'a.fb2', '<isbn>978-5-699-12014-7</isbn>')
+
+    call_command('sopds_isbn_backfill')
+
+    book.refresh_from_db()
+    assert book.isbn == '9785699120147'
+
+
+@pytest.mark.django_db
+def test_backfill_dry_run_does_not_write(tmp_path):
+    config.SOPDS_ROOT_LIB = str(tmp_path)
+    book = _book(tmp_path, 'b.fb2', '<isbn>978-5-699-12014-7</isbn>')
+
+    call_command('sopds_isbn_backfill', '--dry-run')
+
+    book.refresh_from_db()
+    assert book.isbn == ''
+
+
+@pytest.mark.django_db
+def test_backfill_leaves_book_without_isbn_empty(tmp_path):
+    config.SOPDS_ROOT_LIB = str(tmp_path)
+    book = _book(tmp_path, 'c.fb2', '')
+
+    call_command('sopds_isbn_backfill')
+
+    book.refresh_from_db()
+    assert book.isbn == ''
+
+
+@pytest.mark.django_db
+def test_backfill_skips_already_populated(tmp_path):
+    config.SOPDS_ROOT_LIB = str(tmp_path)
+    book = _book(tmp_path, 'd.fb2', '<isbn>978-5-699-12014-7</isbn>')
+    # A different, already-stored ISBN must not be overwritten (out of queryset).
+    Book.objects.filter(pk=book.pk).update(isbn='0306406152')
+
+    call_command('sopds_isbn_backfill')
+
+    book.refresh_from_db()
+    assert book.isbn == '0306406152'


### PR DESCRIPTION
Small follow-up to #63.

## Why

`#63` extracts ISBNs **during scanning**, but a normal incremental scan skips books already present in the DB (`processfile` → `books_skipped`). So the `isbn` column added in migration `0019` stays empty for the **existing** catalogue — only newly-scanned books get it. Backfilling via a full re-scan is expensive and resets `registerdate` and relations.

## What

A `sopds_isbn_backfill` management command that fills the gap cheaply:

- Selects `Book.objects.filter(isbn='', format__in=['fb2','epub'])` (only the formats the parsers read an ISBN from).
- Re-reads each book's file from disk via `dl.getFileData` (handles plain files, zip members and INP entries) and runs the same `create_bookfile` parsers as the scanner.
- Updates **only** the `isbn` field (`.update(isbn=...)`), leaving `registerdate`, authors, genres and series untouched.
- Options: `--dry-run`, `--limit N`, `--verbose`. Prints scanned / updated / no-ISBN / file-missing / parse-error counts.

Usage: `python manage.py sopds_isbn_backfill [--dry-run] [--limit N] [--verbose]`

## Tests

4 new tests: populates ISBN from an on-disk fb2, `--dry-run` writes nothing, a book without an embedded ISBN stays empty, and an already-populated ISBN is not overwritten (out of the queryset). Full suite: **223 passed**, ruff clean.