### PR TITLE
Fix 500 on every web page when authentication is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ All notable changes to this project are documented here. The format is based on
   uses `-c`), so the test environment never drifts from production.
 
 ### Fixed
+- The whole web UI returned **500 for every visitor when `SOPDS_AUTH` is off**.
+  `sopds_login` lets anonymous visitors through in that configuration — which
+  is the point of it — but every view then called `theme_css(request.user)`,
+  which filtered `Theme` by an `AnonymousUser` (`TypeError: Field 'id'
+  expected a number`). Browsing pages and the reader now fall back to the
+  default theme and preferences, and the genuinely per-user endpoints (theme
+  toggle, settings, device sync, bookshelf add/delete/clear, reading position,
+  status, rating) answer **403** instead of raising, since with authentication
+  off there is no user to own that data.
 - **Security:** the OIDC client secret and Telegram API token are entered
   through a masked password field in the constance admin instead of being
   shown in clear text.

--- a/sopds_web_backend/tests/test_anonymous_access.py
+++ b/sopds_web_backend/tests/test_anonymous_access.py
@@ -1,0 +1,97 @@
+"""Browsing the web UI with authentication turned off.
+
+With `SOPDS_AUTH = False` every visitor is an `AnonymousUser`, and `sopds_login`
+lets them through on purpose. Every page then called `theme_css(request.user)`,
+which filtered `Theme` by that AnonymousUser — `TypeError: Field 'id' expected a
+number` — so the whole UI answered 500.
+"""
+import os
+
+import pytest
+from django.urls import reverse
+from constance import config
+
+from opds_catalog.models import Book, Catalog
+
+DATA = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__)))), 'opds_catalog', 'tests', 'data')
+FB2 = '262001.fb2'
+
+
+@pytest.fixture
+def anon(db):
+    config.SOPDS_AUTH = False
+    config.SOPDS_ROOT_LIB = DATA
+    cat = Catalog.objects.create(parent=None, cat_name='.', path='.', cat_type=0)
+    return Book.objects.create(
+        filename=FB2, path='.', filesize=1, format='fb2', cat_type=0,
+        docdate='2011', lang='en', title='The Sanctuary Sparrow',
+        search_title='THE SANCTUARY SPARROW', annotation='', avail=2, catalog=cat,
+    )
+
+
+BROWSING_PAGES = [
+    ('web:main', {}, {}),
+    ('web:catalog', {}, {}),
+    ('web:book', {}, {'lang': 0}),
+    ('web:author', {}, {'lang': 0}),
+    ('web:series', {}, {'lang': 0}),
+    ('web:genre', {}, {}),
+    ('web:searchbooks', {}, {'searchtype': 'm', 'searchterms': 'Sanctuary'}),
+    ('web:searchauthors', {}, {'searchtype': 'm', 'searchterms': 'Peters'}),
+    ('web:searchseries', {}, {'searchtype': 'm', 'searchterms': 'Cadfael'}),
+]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('name, args, query', BROWSING_PAGES)
+def test_browsing_pages_serve_anonymous_visitors(client, anon, name, args, query):
+    resp = client.get(reverse(name, kwargs=args), query)
+    assert resp.status_code == 200
+
+
+@pytest.mark.django_db
+def test_reader_renders_for_an_anonymous_visitor(client, anon):
+    resp = client.get(reverse('web:read', args=[anon.id]))
+    assert resp.status_code == 200
+
+
+@pytest.mark.django_db
+def test_suggestions_work_for_an_anonymous_visitor(client, anon):
+    resp = client.post(reverse('web:suggest'), {'searchterms': 'Sanc', 'suggesttype': 'title'})
+    assert resp.status_code == 200
+
+
+PERSONAL_GET_VIEWS = [
+    ('web:settings', {}),
+    ('web:devicesync', {}),
+    ('web:theme', {}),
+    ('web:bsadd', {}),
+    ('web:bsclear', {}),
+]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('name, args', PERSONAL_GET_VIEWS)
+def test_personal_pages_are_forbidden_not_broken(client, anon, name, args):
+    """These act on one user's rows; with nobody signed in there is no such user.
+    They must say so, not raise TypeError."""
+    assert client.get(reverse(name, kwargs=args)).status_code == 403
+
+
+@pytest.mark.django_db
+def test_personal_book_endpoints_are_forbidden(client, anon):
+    assert client.get(reverse('web:getpos', args=[anon.id])).status_code == 403
+    assert client.get(reverse('web:setpos', args=[anon.id]), {'pos': '1.2'}).status_code == 403
+    assert client.post(reverse('web:bsstatus', args=[anon.id]), {'status': 'read'}).status_code == 403
+    assert client.post(reverse('web:bsrating', args=[anon.id]), {'rating': '4'}).status_code == 403
+    assert client.delete('%s?book=%s' % (reverse('web:bsdel'), anon.id)).status_code == 403
+
+
+@pytest.mark.django_db
+def test_personal_pages_still_work_when_signed_in(client, anon, django_user_model):
+    config.SOPDS_AUTH = True
+    user = django_user_model.objects.create_user(username='reader', password='pw')
+    client.force_login(user)
+    assert client.get(reverse('web:settings')).status_code == 200
+    assert client.post(reverse('web:bsrating', args=[anon.id]), {'rating': '4'}).status_code == 200

--- a/sopds_web_backend/views.py
+++ b/sopds_web_backend/views.py
@@ -1,3 +1,4 @@
+from functools import wraps
 from random import randint
 
 from django.shortcuts import render, redirect, get_object_or_404
@@ -11,7 +12,7 @@ from django.views.decorators.vary import vary_on_headers
 from django.urls import reverse, reverse_lazy
 from django.utils.html import strip_tags
 from django.utils.http import url_has_allowed_host_and_scheme
-from django.http import HttpResponseRedirect
+from django.http import HttpResponseForbidden, HttpResponseRedirect
 
 
 from opds_catalog import models
@@ -36,6 +37,9 @@ def _int_param(request, name, default=0):
         return default
 
 
+DEFAULT_THEME_CSS = "css/sopds.css"
+
+
 def theme_css(user):
     """Return the user's theme key in a single query (instead of exists()+get()).
 
@@ -43,15 +47,47 @@ def theme_css(user):
     theme keys, not real files: the single lectern.css stylesheet is always
     loaded and sopds_main.html selects light/dark via `data-theme` from whether
     this key contains "dark".
+
+    An anonymous visitor (which every visitor is when SOPDS_AUTH is off) has no
+    row and cannot be used as a filter value, so they get the default.
     """
+    if not user.is_authenticated:
+        return DEFAULT_THEME_CSS
+
     theme = Theme.objects.filter(user=user).first()
-    return theme.theme_css if theme else "css/sopds.css"
+    return theme.theme_css if theme else DEFAULT_THEME_CSS
 
 
 def user_prefs(user):
-    """Per-user preferences row (theme + reader settings), created on demand."""
+    """Per-user preferences row (theme + reader settings), created on demand.
+
+    Anonymous visitors get an unsaved row of defaults: there is nobody to own
+    the preferences, but the reader still has to render.
+    """
+    if not user.is_authenticated:
+        return Theme(theme_css=DEFAULT_THEME_CSS)
+
     prefs, _ = Theme.objects.get_or_create(user=user)
     return prefs
+
+
+def personal_view(function):
+    """Guard for views that read or write one specific user's rows.
+
+    `sopds_login` deliberately lets everyone through when SOPDS_AUTH is off, and
+    that is right for browsing the catalogue. It is not right for the bookshelf,
+    the theme toggle or the sync password: those filter `Theme`/`bookshelf`/
+    `KosyncCredential` by `request.user`, and an `AnonymousUser` is not a value
+    the ORM can filter on — every one of them raised TypeError and returned 500.
+    With authentication off there is no user to own that data, so answer 403.
+    """
+    @wraps(function)
+    def _wrapped(request, *args, **kwargs):
+        if not request.user.is_authenticated:
+            return HttpResponseForbidden(_('This page requires a signed-in user.'))
+        return function(request, *args, **kwargs)
+
+    return _wrapped
 
 
 def sopds_login(function=None, redirect_field_name=REDIRECT_FIELD_NAME, url=None):
@@ -358,6 +394,7 @@ def SearchBooksView(request):
 
 @vary_on_headers("HTTP_ACCEPT_LANGUAGE")
 @sopds_login(url='web:login')
+@personal_view
 def ThemeView(request):
     theme = Theme.objects.filter(user=request.user).first()
     if theme:
@@ -370,6 +407,7 @@ def ThemeView(request):
 
 @vary_on_headers("HTTP_ACCEPT_LANGUAGE")
 @sopds_login(url='web:login')
+@personal_view
 def SettingsView(request):
     prefs = user_prefs(request.user)
     if request.method == 'POST':
@@ -397,6 +435,7 @@ def SettingsView(request):
 
 @vary_on_headers("HTTP_ACCEPT_LANGUAGE")
 @sopds_login(url='web:login')
+@personal_view
 def DeviceSyncView(request):
     """Set the KOReader sync password and show connection details for KOReader
     (kosync) and Moon+ Reader (WebDAV).
@@ -727,6 +766,7 @@ def GenresView(request):
 
 @vary_on_headers("HTTP_ACCEPT_LANGUAGE")
 @sopds_login(url='web:login')
+@personal_view
 def BSAddView(request):
     book = request.GET.get('book')
     if book:
@@ -749,6 +789,7 @@ def BSAddView(request):
 
 @vary_on_headers("HTTP_ACCEPT_LANGUAGE")
 @sopds_login(url='web:login')
+@personal_view
 def BSDelView(request):
     book = request.GET.get('book') or request.POST.get('book')
     if book:
@@ -769,6 +810,7 @@ def BSDelView(request):
 
 @vary_on_headers("HTTP_ACCEPT_LANGUAGE")
 @sopds_login(url='web:login')
+@personal_view
 def BSSetPos(request, book_id):
     pos = request.GET.get('pos') if request.GET else None
 
@@ -787,6 +829,7 @@ def BSSetPos(request, book_id):
 
 @vary_on_headers("HTTP_ACCEPT_LANGUAGE")
 @sopds_login(url='web:login')
+@personal_view
 def BSGetPos(request, book_id):
     shelf = bookshelf.objects.filter(user=request.user, book_id=book_id).first()
     response = HttpResponse()
@@ -796,12 +839,14 @@ def BSGetPos(request, book_id):
 
 @vary_on_headers("HTTP_ACCEPT_LANGUAGE")
 @sopds_login(url='web:login')
+@personal_view
 def BSClearView(request):
     bookshelf.objects.filter(user=request.user).delete()
     return redirect("%s?searchtype=u" % reverse("web:searchbooks"))
 
 
 @sopds_login(url='web:login')
+@personal_view
 def BSSetStatus(request, book_id):
     status = request.POST.get('status', '')
     valid = {c[0] for c in bookshelf.STATUS_CHOICES}
@@ -814,6 +859,7 @@ def BSSetStatus(request, book_id):
 
 
 @sopds_login(url='web:login')
+@personal_view
 def BSSetRating(request, book_id):
     try:
         rating = int(request.POST.get('rating'))


### PR DESCRIPTION
Turning `SOPDS_AUTH` off is a supported configuration — `sopds_login` lets anonymous visitors straight through when it is set — but the UI behind it was never reachable that way. Every view calls `theme_css(request.user)`, which filters `Theme` by the user, and an `AnonymousUser` is not a value the ORM can filter on:

```
TypeError: Field 'id' expected a number but got <SimpleLazyObject: AnonymousUser>
```

The result was HTTP 500 on the catalogue, book, author, series, genre, search and reader pages alike.

## Changes

- Browsing does not need a user, so `theme_css` and `user_prefs` fall back to the default theme and an unsaved defaults row.
- The bookshelf, theme toggle, settings, device-sync and reading-position endpoints genuinely do need one — with authentication off there is nobody to own those rows — so a new `personal_view` decorator answers **403** rather than letting the same `TypeError` through.

## Tests

`sopds_web_backend/tests/test_anonymous_access.py`: 18 tests covering the browsing pages, the reader, suggestions, and the per-user endpoints. 15 of them fail without this change.