### PR TITLE
Offer the in-browser reader only for FB2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ All notable changes to this project are documented here. The format is based on
   toggle, settings, device sync, bookshelf add/delete/clear, reading position,
   status, rating) answer **403** instead of raising, since with authentication
   off there is no user to own that data.
+- The **Read** link was rendered for every book, but the in-browser reader is
+  an FB2-to-XHTML transform: clicking it on an EPUB, MOBI, PDF or DjVu fed a
+  binary container to the XML parser and returned **500**. Both reader views
+  now raise `Http404` for anything but FB2 (matching the guard `ConvertFB2`
+  already had), and the book list only offers the link where it works.
 - **Security:** the OIDC client secret and Telegram API token are entered
   through a masked password field in the constance admin instead of being
   shown in clear text.

--- a/opds_catalog/dl.py
+++ b/opds_catalog/dl.py
@@ -470,6 +470,13 @@ def ReadFB2(request, book_id):
     """ Загрузка книги """
     book = get_object_or_404(Book, id=book_id)
 
+    # The reader renders a book by running FB2_22_xhtml.xsl over its XML, so it
+    # only works for FB2. Anything else reached ET.parse() and died there with a
+    # 500 (an EPUB or MOBI is a binary container, not XML). Mirror the guard
+    # ConvertFB2 already has.
+    if book.format != 'fb2':
+        raise Http404
+
     if config.SOPDS_AUTH and request.user.is_authenticated:
         bookshelf.objects.get_or_create(user=request.user, book=book)
 

--- a/opds_catalog/tests/test_reader_format.py
+++ b/opds_catalog/tests/test_reader_format.py
@@ -1,0 +1,64 @@
+"""The in-browser reader only handles FB2; other formats must 404, not 500."""
+import os
+
+import pytest
+from django.urls import reverse
+from constance import config
+
+from opds_catalog.models import Book, Catalog
+
+DATA = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
+FB2 = '262001.fb2'
+
+
+@pytest.fixture
+def library(db):
+    config.SOPDS_AUTH = True
+    config.SOPDS_ROOT_LIB = DATA
+    return Catalog.objects.create(parent=None, cat_name='.', path='.', cat_type=0)
+
+
+@pytest.fixture
+def client(client, django_user_model, db):
+    user = django_user_model.objects.create_user(username='reader', password='pw')
+    client.force_login(user)
+    return client
+
+
+def make_book(cat, fmt, filename=FB2):
+    return Book.objects.create(
+        filename=filename, path='.', filesize=1, format=fmt, cat_type=0,
+        docdate='2011', lang='en', title='Book in %s' % fmt,
+        search_title='BOOK IN %s' % fmt.upper(), annotation='', avail=2, catalog=cat,
+    )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('fmt', ['epub', 'mobi', 'pdf', 'djvu'])
+def test_reader_404s_for_formats_it_cannot_render(client, library, fmt):
+    """Previously these reached lxml's ET.parse() on a binary container and
+    raised, returning 500."""
+    book = make_book(library, fmt)
+    assert client.get(reverse('opds:read', args=[book.id])).status_code == 404
+    assert client.get(reverse('web:read', args=[book.id])).status_code == 404
+
+
+@pytest.mark.django_db
+def test_reader_still_renders_fb2(client, library):
+    book = make_book(library, 'fb2')
+    resp = client.get(reverse('opds:read', args=[book.id]))
+    assert resp.status_code == 200
+    assert resp['Content-Type'].startswith('text/html')
+    assert client.get(reverse('web:read', args=[book.id])).status_code == 200
+
+
+@pytest.mark.django_db
+def test_book_list_offers_read_only_for_fb2(client, library):
+    make_book(library, 'fb2')
+    make_book(library, 'epub')
+    body = client.get(reverse('web:searchbooks'), {'searchtype': 'm', 'searchterms': 'BOOK'}).content.decode()
+
+    fb2 = Book.objects.get(format='fb2')
+    epub = Book.objects.get(format='epub')
+    assert reverse('web:read', args=[fb2.id]) in body
+    assert reverse('web:read', args=[epub.id]) not in body

--- a/sopds_web_backend/templates/sopds_books.html
+++ b/sopds_web_backend/templates/sopds_books.html
@@ -39,7 +39,10 @@
 			{% if b.format == 'fb2' and fb2tomobi %}
 			   <i><a href="{% url 'opds_catalog:convert' b.id 'mobi' %}"><span class="label small">mobi</span></a></i>&nbsp;
 			{% endif %}			
-            <i><a href="{% url 'web:read' b.id %}"><span class="label small">{% trans "Read" %}</span></a></i>&nbsp;
+			{% if b.format == 'fb2' %}
+			   {# The in-browser reader is an FB2-to-XHTML transform; other formats 404. #}
+			   <i><a href="{% url 'web:read' b.id %}"><span class="label small">{% trans "Read" %}</span></a></i>&nbsp;
+			{% endif %}
 			{% if b.bookshelf %}
 			&nbsp;&nbsp;<i><a href="#"
 			      hx-delete="{% url 'web:bsdel' %}?book={{ b.id }}"

--- a/sopds_web_backend/views.py
+++ b/sopds_web_backend/views.py
@@ -1036,6 +1036,13 @@ def LogoutView(request):
 @vary_on_headers("HTTP_ACCEPT_LANGUAGE")
 @sopds_login(url='web:login')
 def BookReaderView(request, book_id):
+    # The page is only a shell: it fetches opds:read, which can render FB2 and
+    # nothing else. Refuse here as well, so an unreadable format fails as a 404
+    # on the link instead of loading a reader that stays permanently empty.
+    book = get_object_or_404(Book, id=book_id)
+    if book.format != 'fb2':
+        raise Http404
+
     prefs = user_prefs(request.user)
     args = {}
     args['current'] = 'reader'


### PR DESCRIPTION
The reader renders a book by running `FB2_22_xhtml.xsl` over its XML, so FB2 is the only format it can handle — but the **Read** link was rendered for every book in the list, and `ReadFB2` had no format check. Clicking it on an EPUB, MOBI, PDF or DjVu handed a binary container to lxml and returned **500**.

## Changes

- `dl.ReadFB2` and `BookReaderView` raise `Http404` for anything but FB2, mirroring the guard `ConvertFB2` already carries.
- The book list only shows the link where it leads somewhere.

Reading EPUB in the browser would need a real client-side reader (epub.js or equivalent) and is left as separate work; this only stops the dead link.

## Tests

`opds_catalog/tests/test_reader_format.py`: 404 for epub/mobi/pdf/djvu on both routes, FB2 still renders, and the list offers the link only for FB2.