### PR TITLE
Cache covers by content validator and answer conditional GETs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ All notable changes to this project are documented here. The format is based on
 - Tooling config in `pyproject.toml` (ruff, mypy); `CONTRIBUTING.md`.
 
 ### Changed
+- Covers and thumbnails answer conditional GETs. `/opds/cover/<id>/` and
+  `/opds/thumb/<id>/` now send an `ETag` derived from the containing file's
+  size and mtime — one `stat()`, no unzipping — so a reader revalidating with
+  `If-None-Match` gets a bodyless **304** instead of a re-extracted JPEG.
+  Behind that, the body cache is keyed on the ETag rather than on the URL as
+  `cache_page` was: replacing a book in place now invalidates its cover at
+  once instead of serving the previous one until `SOPDS_CACHE_TIME` ran out.
+  A book with no readable cover is cached as such, so it is not re-parsed on
+  every page view, and the responses are marked `Cache-Control: public` (they
+  carry no per-user content). `SOPDS_CACHE_TIME` is read per request, so
+  changing it in the admin no longer needs a restart.
 - Incremental scan no longer rewrites the whole `Book` table on every run. The
   start-of-scan `UPDATE opds_catalog_book SET avail=1` full-table sweep is
   replaced by a scratch `ScanSeen` table: the scanner records the id of each
@@ -41,6 +52,9 @@ All notable changes to this project are documented here. The format is based on
   binary container to the XML parser and returned **500**. Both reader views
   now raise `Http404` for anything but FB2 (matching the guard `ConvertFB2`
   already had), and the book list only offers the link where it works.
+- `/opds/thumb/` (the `covertmpl` route) returned **500**: it was wired to
+  `Cover`, which takes a mandatory `book_id`, so requesting it raised
+  `TypeError`. It now serves the no-cover placeholder it was meant to.
 - **Security:** the OIDC client secret and Telegram API token are entered
   through a masked password field in the constance admin instead of being
   shown in clear text.

--- a/opds_catalog/dl.py
+++ b/opds_catalog/dl.py
@@ -2,6 +2,7 @@
 import os
 import codecs
 import base64
+import hashlib
 import io
 import shlex
 import subprocess
@@ -9,9 +10,11 @@ import lxml.etree as ET
 from re import search
 import logging
 
+from django.core.cache import cache
 from django.http import HttpResponse, Http404
 from django.shortcuts import get_object_or_404
-from django.views.decorators.cache import cache_page
+from django.utils.cache import patch_cache_control
+from django.views.decorators.http import etag
 
 from opds_catalog.models import Book, bookshelf
 from opds_catalog import settings, utils, opdsdb, fb2parse
@@ -34,6 +37,82 @@ logger = logging.getLogger(__name__)
 # tiny-but-huge-dimension image raises DecompressionBombError instead of
 # allocating gigabytes (real covers are far below this).
 Image.MAX_IMAGE_PIXELS = 64_000_000
+
+
+def container_path(book):
+    """Absolute path of the file that physically holds the book.
+
+    That is the book file itself for a plain catalog entry, and the containing
+    zip for an archived one (for INPX entries the .inpx/.inp parts of the stored
+    path are not real directories and have to be stripped first).
+    """
+    full_path = os.path.join(config.SOPDS_ROOT_LIB, book.path)
+    if book.cat_type == opdsdb.CAT_INP:
+        # Убираем из пути INPX и INP файл
+        inp_path, zip_name = os.path.split(full_path)
+        inpx_path, inp_name = os.path.split(inp_path)
+        path, inpx_name = os.path.split(inpx_path)
+        full_path = os.path.join(path, zip_name)
+
+    if book.cat_type == opdsdb.CAT_NORMAL:
+        return os.path.join(full_path, book.filename)
+
+    return full_path
+
+
+def compute_cover_etag(book_id, thumbnail=False):
+    """Validator for the cover/thumbnail views, computed without opening the book.
+
+    Extracting a cover means unzipping and parsing the book, so the point of the
+    ETag is to answer a revalidation with 304 *before* any of that happens. The
+    validator therefore uses only what a single `stat()` gives us: the size and
+    mtime of the containing file, plus the entry that identifies the book inside
+    it. The scanner keys books on (filename, path) and never refreshes the row
+    when a file is replaced in place, so `Book.filesize` cannot be trusted here —
+    the on-disk mtime can.
+
+    Returns None (no ETag, no conditional handling, no caching) when the book or
+    its file is gone; those paths end in a 404 or the no-cover placeholder.
+    """
+    try:
+        book = Book.objects.only('path', 'filename', 'cat_type').get(id=book_id)
+        st = os.stat(container_path(book))
+    except (Book.DoesNotExist, OSError):
+        return None
+
+    key = '%s|%s|%s|%s|%s' % (
+        book_id, book.filename, st.st_size, st.st_mtime_ns,
+        settings.THUMB_SIZE if thumbnail else 'full',
+    )
+    return '"%s"' % hashlib.sha256(key.encode('utf-8')).hexdigest()[:32]
+
+
+def cover_etag(request, book_id, thumbnail=False):
+    """`compute_cover_etag`, memoised for the duration of one request.
+
+    The validator is needed twice per request — once by the `etag` decorator to
+    answer conditional GETs, once by the view as its cache key — and each call
+    costs a query plus a stat. Caching it on the request keeps that at one.
+    """
+    memo = (book_id, bool(thumbnail))
+    if request is not None and getattr(request, '_cover_etag_for', None) == memo:
+        return request._cover_etag
+
+    value = compute_cover_etag(book_id, thumbnail)
+    if request is not None:
+        request._cover_etag_for = memo
+        request._cover_etag = value
+
+    return value
+
+
+def nocover_response():
+    """The placeholder image served when a book has no extractable cover."""
+    if not os.path.exists(config.SOPDS_NOCOVER_PATH):
+        raise Http404
+
+    with open(config.SOPDS_NOCOVER_PATH, 'rb') as f:
+        return HttpResponse(f.read(), content_type='image/jpeg')
 
 
 def getFileName(book):
@@ -251,25 +330,20 @@ def Download(request, book_id, zip_flag):
     return response
 
 
-# Новая версия (0.42) процедуры извлечения обложек из файлов книг fb2, epub, mobi
-@cache_page(config.SOPDS_CACHE_TIME)
-def Cover(request, book_id, thumbnail=False):
-    """ Загрузка обложки """
-    book = get_object_or_404(Book, id=book_id)
-    response = HttpResponse()
-    full_path = os.path.join(config.SOPDS_ROOT_LIB, book.path)
-    if book.cat_type == opdsdb.CAT_INP:
-        # Убираем из пути INPX и INP файл
-        inp_path, zip_name = os.path.split(full_path)
-        inpx_path, inp_name = os.path.split(inp_path)
-        path, inpx_name = os.path.split(inpx_path)
-        full_path = os.path.join(path,zip_name)
+def extract_cover(book, thumbnail=False):
+    """Cover bytes for one book, or None when it has none we can read.
 
+    This is the expensive part — it opens (and for an archived book, unzips) the
+    file and runs a format parser over it — which is why both the ETag and the
+    cache above it exist to avoid reaching here.
+    """
+    full_path = container_path(book)
+
+    image = None
     try:
         if book.cat_type == opdsdb.CAT_NORMAL:
-            file_path = os.path.join(full_path, book.filename)
-            fo = codecs.open(file_path, "rb")
-            book_data = create_bookfile(fo,book.filename)
+            fo = codecs.open(full_path, "rb")
+            book_data = create_bookfile(fo, book.filename)
             image = book_data.extract_cover_memory()
             #fb2.parse(fo, 0)
             fo.close()
@@ -284,35 +358,58 @@ def Cover(request, book_id, thumbnail=False):
             z.close()
             fz.close()
     except Exception:
-        book_data = None
-        image = None
+        return None
+
+    if image and thumbnail:
+        try:
+            # Cover bytes are attacker-controlled; a decompression-bomb
+            # image raises DecompressionBombError (Image.MAX_IMAGE_PIXELS)
+            # instead of allocating huge memory. Fall back to no-cover.
+            thumb = Image.open(io.BytesIO(image)).convert('RGB')
+            thumb.thumbnail((settings.THUMB_SIZE, settings.THUMB_SIZE), Image.LANCZOS)
+            tfile = io.BytesIO()
+            thumb.save(tfile, 'JPEG')
+            image = tfile.getvalue()
+        except Exception:
+            logger.warning('Thumbnail generation failed for book %s', book.id)
+            return None
+
+    return image or None
+
+
+# Новая версия (0.42) процедуры извлечения обложек из файлов книг fb2, epub, mobi
+#
+# Three layers guard the extraction, cheapest first: the `etag` decorator answers
+# a reader's revalidation with 304 without running the view at all; the shared
+# cache below returns the bytes without touching the file; only a real miss pays
+# for unzipping and parsing the book.
+#
+# The cache is keyed on the ETag, not on the URL as `cache_page` was: the
+# validator tracks the file's mtime, so replacing a book in place now yields a
+# new key instead of serving the previous cover until the TTL ran out.
+@etag(cover_etag)
+def Cover(request, book_id, thumbnail=False):
+    """ Загрузка обложки """
+    validator = cover_etag(request, book_id, thumbnail)
+    cache_key = 'sopds-cover:%s' % validator.strip('"') if validator else None
+
+    image = cache.get(cache_key) if cache_key else None
+    if image is None:
+        book = get_object_or_404(Book, id=book_id)
+        # b'' is the "this book has no cover" marker: caching it too keeps a
+        # coverless book from being re-parsed on every page view.
+        image = extract_cover(book, thumbnail) or b''
+        if cache_key:
+            cache.set(cache_key, image, config.SOPDS_CACHE_TIME)
 
     if image:
-        response["Content-Type"] = 'image/jpeg'
-        if thumbnail:
-            try:
-                # Cover bytes are attacker-controlled; a decompression-bomb
-                # image raises DecompressionBombError (Image.MAX_IMAGE_PIXELS)
-                # instead of allocating huge memory. Fall back to no-cover.
-                thumb = Image.open(io.BytesIO(image)).convert('RGB')
-                thumb.thumbnail((settings.THUMB_SIZE, settings.THUMB_SIZE), Image.LANCZOS)
-                tfile = io.BytesIO()
-                thumb.save(tfile, 'JPEG')
-                image = tfile.getvalue()
-            except Exception:
-                logger.warning('Thumbnail generation failed for book %s', book_id)
-                image = None
-        if image:
-            response.write(image)
+        response = HttpResponse(image, content_type='image/jpeg')
+    else:
+        response = nocover_response()
 
-    if not image:
-        if os.path.exists(config.SOPDS_NOCOVER_PATH):
-            response["Content-Type"] = 'image/jpeg'
-            f = open(config.SOPDS_NOCOVER_PATH, "rb")
-            response.write(f.read())
-            f.close()
-        else:
-            raise Http404
+    # Covers carry no per-user content and are served without authentication, so
+    # a shared proxy may cache them too.
+    patch_cache_control(response, public=True, max_age=config.SOPDS_CACHE_TIME)
 
     return response
 
@@ -379,6 +476,17 @@ def Cover0(request, book_id, thumbnail = False):
 
 def Thumbnail(request, book_id):
     return Cover(request, book_id, True)
+
+
+def NoCover(request):
+    """Book-less placeholder cover, for templates that need a default image.
+
+    The `covertmpl` route used to point straight at `Cover`, which takes a
+    mandatory book_id — requesting it raised TypeError and returned 500.
+    """
+    response = nocover_response()
+    patch_cache_control(response, public=True, max_age=config.SOPDS_CACHE_TIME)
+    return response
 
 
 def ConvertFB2(request, book_id, convert_type):

--- a/opds_catalog/tests/test_cover_cache.py
+++ b/opds_catalog/tests/test_cover_cache.py
@@ -1,0 +1,154 @@
+"""Conditional-GET and caching behaviour of the cover/thumbnail views."""
+import os
+import shutil
+
+import pytest
+from django.core.cache import cache
+from django.urls import reverse
+from constance import config
+
+from opds_catalog import dl
+from opds_catalog.models import Book, Catalog
+
+DATA = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
+FB2 = '262001.fb2'
+
+
+@pytest.fixture(autouse=True)
+def clean_cache():
+    # The default cache is process-wide and outlives a test; covers cached by
+    # one test would otherwise be served to the next.
+    cache.clear()
+    yield
+    cache.clear()
+
+
+@pytest.fixture
+def library(db, tmp_path):
+    # A private copy of the sample book: the ETag keys on the file's mtime, and
+    # one test rewrites it.
+    shutil.copy(os.path.join(DATA, FB2), tmp_path / FB2)
+    config.SOPDS_ROOT_LIB = str(tmp_path)
+    cat = Catalog.objects.create(parent=None, cat_name='.', path='.', cat_type=0)
+    return Book.objects.create(
+        filename=FB2, path='.', filesize=os.path.getsize(tmp_path / FB2),
+        format='fb2', cat_type=0, docdate='2011', lang='en',
+        title='The Sanctuary Sparrow', search_title='THE SANCTUARY SPARROW',
+        annotation='', avail=2, catalog=cat,
+    )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('route', ['opds:cover', 'opds:thumb'])
+def test_cover_sets_etag_and_public_cache_control(client, library, route):
+    resp = client.get(reverse(route, args=[library.id]))
+    assert resp.status_code == 200
+    assert resp['ETag']
+    assert 'public' in resp['Cache-Control']
+    assert 'max-age' in resp['Cache-Control']
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('route', ['opds:cover', 'opds:thumb'])
+def test_revalidation_returns_304_without_a_body(client, library, route):
+    url = reverse(route, args=[library.id])
+    etag = client.get(url)['ETag']
+
+    resp = client.get(url, headers={'if-none-match': etag})
+    assert resp.status_code == 304
+    assert resp.content == b''
+
+
+@pytest.mark.django_db
+def test_cover_and_thumbnail_have_different_etags(client, library):
+    cover = client.get(reverse('opds:cover', args=[library.id]))['ETag']
+    thumb = client.get(reverse('opds:thumb', args=[library.id]))['ETag']
+    assert cover != thumb
+
+
+@pytest.mark.django_db
+def test_etag_changes_when_the_file_is_replaced(client, library, tmp_path):
+    url = reverse('opds:cover', args=[library.id])
+    before = client.get(url)['ETag']
+
+    # Replaced in place: the scanner keys books on (filename, path) and would
+    # not touch the row, so only the on-disk mtime/size can catch this.
+    path = tmp_path / FB2
+    path.write_bytes(path.read_bytes() + b'<!-- changed -->')
+
+    assert client.get(url)['ETag'] != before
+
+
+@pytest.mark.django_db
+def test_a_replaced_file_is_not_served_from_the_cache(client, library, tmp_path):
+    """The regression `cache_page` had: it keyed on the URL, so a book replaced
+    in place kept serving its previous cover until the TTL expired."""
+    url = reverse('opds:cover', args=[library.id])
+    assert client.get(url).status_code == 200          # populates the cache
+
+    # Replace the book with one whose cover we cannot read.
+    (tmp_path / FB2).write_bytes(b'not a book')
+
+    resp = client.get(url)
+    assert resp.status_code == 200
+    with open(config.SOPDS_NOCOVER_PATH, 'rb') as f:
+        assert resp.content == f.read()
+
+
+@pytest.mark.django_db
+def test_a_cache_hit_does_not_reopen_the_book(client, library, monkeypatch):
+    url = reverse('opds:cover', args=[library.id])
+    assert client.get(url).status_code == 200
+
+    def fail(*args, **kwargs):
+        raise AssertionError('the book was parsed again on a cache hit')
+
+    monkeypatch.setattr(dl, 'extract_cover', fail)
+    assert client.get(url).status_code == 200
+
+
+@pytest.mark.django_db
+def test_a_coverless_book_is_cached_too(client, library, tmp_path, monkeypatch):
+    (tmp_path / FB2).write_bytes(b'not a book')
+    url = reverse('opds:cover', args=[library.id])
+    assert client.get(url).status_code == 200
+
+    def fail(*args, **kwargs):
+        raise AssertionError('a coverless book was parsed again on a cache hit')
+
+    monkeypatch.setattr(dl, 'extract_cover', fail)
+    assert client.get(url).status_code == 200
+
+
+@pytest.mark.django_db
+def test_etag_is_none_for_a_missing_file(client, library, tmp_path):
+    os.remove(tmp_path / FB2)
+    # No validator to offer, but the placeholder is still served.
+    assert dl.cover_etag(None, library.id) is None
+    assert client.get(reverse('opds:cover', args=[library.id])).status_code == 200
+
+
+@pytest.mark.django_db
+def test_etag_is_none_for_a_missing_book(library):
+    assert dl.cover_etag(None, library.id + 1000) is None
+
+
+@pytest.mark.django_db
+def test_missing_book_is_404_not_a_cached_placeholder(client, library):
+    assert client.get(reverse('opds:cover', args=[library.id + 1000])).status_code == 404
+
+
+@pytest.mark.django_db
+def test_covertmpl_serves_the_placeholder(client):
+    # Used to be routed at Cover, which needs a book_id, and returned 500.
+    resp = client.get(reverse('opds:covertmpl'))
+    assert resp.status_code == 200
+    assert resp['Content-Type'] == 'image/jpeg'
+    assert len(resp.content) > 0
+
+
+@pytest.mark.django_db
+def test_cache_timeout_is_read_per_request(client, library):
+    config.SOPDS_CACHE_TIME = 77
+    resp = client.get(reverse('opds:cover', args=[library.id]))
+    assert 'max-age=77' in resp['Cache-Control']

--- a/opds_catalog/urls.py
+++ b/opds_catalog/urls.py
@@ -49,7 +49,7 @@ urlpatterns = [
     re_path(r'^download/(?P<book_id>[0-9]+)/(?P<zip_flag>[0-1])/$',dl.Download, name='download'),
     re_path(r'^cover/(?P<book_id>[0-9]+)/$',dl.Cover, name='cover'),
     re_path(r'^thumb/(?P<book_id>[0-9]+)/$',dl.Thumbnail, name='thumb'),
-    re_path(r'^thumb/$',dl.Cover, name='covertmpl'),
+    re_path(r'^thumb/$',dl.NoCover, name='covertmpl'),
     re_path(r'^read/(?P<book_id>[0-9]+)/$', dl.ReadFB2, name='read'),
 
     re_path(r'^$',feeds.MainFeed(), name='main'),


### PR DESCRIPTION
Serving a cover means opening the book — and for an archived one, unzipping it — and running a format parser over it. `cache_page` sat in front of that, but it keys on the request URL, so a book replaced in place kept serving its previous cover for the whole TTL, and every request still transferred the full JPEG because there was no validator to revalidate against.

## Changes

- **`ETag` + 304.** Computed from the containing file's size and mtime: one `stat()`, no unzipping, so the `etag` decorator answers a reader's `If-None-Match` with a bodyless 304 before the view runs at all. `Book.filesize` cannot be used — the scanner keys books on `(filename, path)` and never refreshes the row when a file is replaced in place.
- **Cache keyed on that validator** instead of on the URL, so a replaced file invalidates its cover immediately.
- A book with no readable cover is cached as such, so it is not re-parsed on every page view.
- Responses are marked `Cache-Control: public` — covers carry no per-user content and are already served unauthenticated.
- `SOPDS_CACHE_TIME` was read at import time by the `cache_page` decorator, which hit the DB during app loading and froze the TTL until a restart; it is now read per request.

## Also fixed

`/opds/thumb/` (the `covertmpl` route) returned **500**: it was wired to `Cover`, whose `book_id` is mandatory, so the route raised `TypeError`. It now serves the no-cover placeholder it was meant to.

## Tests

`opds_catalog/tests/test_cover_cache.py`: 14 tests covering the ETag, the 304 round-trip, cover/thumbnail key separation, invalidation on file replacement, cache hits not reopening the book, and the `covertmpl` route.