### PR TITLE
Require authentication for every route that serves book content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,17 @@ All notable changes to this project are documented here. The format is based on
   slow (lost Index-Only Scan) until autovacuum catches up.
 
 ### Security
+- **Catalogue content was reachable without authentication.** With
+  `SOPDS_AUTH` on, the OPDS feeds and `/opds/download/` correctly answered
+  401, but `/opds/cover/`, `/opds/thumb/`, `/opds/convert/` and — worst of the
+  four — `/opds/read/` did not: the reader route handed out the **full text of
+  any book** to anyone who knew (or guessed) an id, and the cover routes
+  exposed cover art, which usually carries the title and author. All four now
+  go through the same `require_catalog_access` guard `Download` had inline,
+  accepting either a session login or OPDS Basic auth. The check runs outside
+  the cover ETag and cache, so an anonymous request cannot spend CPU
+  unzipping books or populate the cache either. The book-less no-cover
+  placeholder stays open — it carries nothing from the catalogue.
 - Brute-force throttle on the web login form: after 10 failed attempts per
   client IP the login is locked out for 5 minutes (shared cache, so it holds
   across workers). A successful login clears the counter.

--- a/opds_catalog/dl.py
+++ b/opds_catalog/dl.py
@@ -7,6 +7,7 @@ import io
 import shlex
 import subprocess
 import lxml.etree as ET
+from functools import wraps
 from re import search
 import logging
 
@@ -37,6 +38,28 @@ logger = logging.getLogger(__name__)
 # tiny-but-huge-dimension image raises DecompressionBombError instead of
 # allocating gigabytes (real covers are far below this).
 Image.MAX_IMAGE_PIXELS = 64_000_000
+
+
+def require_catalog_access(view):
+    """Refuse anonymous access to catalogue content while SOPDS_AUTH is on.
+
+    Factored out of `Download`, which had the only copy of this. A session login
+    counts, and so does OPDS Basic auth: e-readers fetch cover art with the same
+    credentials they use for the feed and cannot carry a session cookie.
+
+    Note this runs *outside* the ETag and the cache, so an unauthenticated
+    request is turned away before it can consume either.
+    """
+    @wraps(view)
+    def _wrapped(request, *args, **kwargs):
+        if config.SOPDS_AUTH and not request.user.is_authenticated:
+            # Returns the request (with .user set) on success, a 401 otherwise.
+            result = BasicAuthMiddleware().process_request(request)
+            if result is not None and not hasattr(result, 'user'):
+                return result
+        return view(request, *args, **kwargs)
+
+    return _wrapped
 
 
 def container_path(book):
@@ -248,18 +271,13 @@ def getFileDataMobi(book):
     return getFileDataConv(book,'mobi')
 
 
+@require_catalog_access
 def Download(request, book_id, zip_flag):
     """ Загрузка файла книги """
     book = get_object_or_404(Book, id=book_id)
 
-    if config.SOPDS_AUTH:
-        if not request.user.is_authenticated:
-            bau = BasicAuthMiddleware()
-            request = bau.process_request(request)
-            if not hasattr(request, 'user'):
-                return request
-        if request.user.is_authenticated:
-            bookshelf.objects.get_or_create(user=request.user, book=book)
+    if config.SOPDS_AUTH and request.user.is_authenticated:
+        bookshelf.objects.get_or_create(user=request.user, book=book)
 
     full_path=os.path.join(config.SOPDS_ROOT_LIB,book.path)
     
@@ -387,6 +405,7 @@ def extract_cover(book, thumbnail=False):
 # The cache is keyed on the ETag, not on the URL as `cache_page` was: the
 # validator tracks the file's mtime, so replacing a book in place now yields a
 # new key instead of serving the previous cover until the TTL ran out.
+@require_catalog_access
 @etag(cover_etag)
 def Cover(request, book_id, thumbnail=False):
     """ Загрузка обложки """
@@ -489,6 +508,7 @@ def NoCover(request):
     return response
 
 
+@require_catalog_access
 def ConvertFB2(request, book_id, convert_type):
     """ Выдача файла книги после конвертации в EPUB или mobi """
     book = get_object_or_404(Book, id=book_id)
@@ -574,6 +594,7 @@ def ConvertFB2(request, book_id, convert_type):
     return response
 
 
+@require_catalog_access
 def ReadFB2(request, book_id):
     """ Загрузка книги """
     book = get_object_or_404(Book, id=book_id)

--- a/opds_catalog/tests/test_content_auth.py
+++ b/opds_catalog/tests/test_content_auth.py
@@ -1,0 +1,106 @@
+"""Every route that serves catalogue content honours SOPDS_AUTH.
+
+The OPDS feeds and `Download` already answered 401 to an anonymous request, but
+the cover, thumbnail, convert and — worst of the four — the reader route did
+not: `/opds/read/<id>/` handed out the full text of any book to anybody who
+knew an id.
+"""
+import base64
+import os
+
+import pytest
+from django.urls import reverse
+from constance import config
+
+from opds_catalog.models import Book, Catalog
+
+DATA = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
+FB2 = '262001.fb2'
+
+
+@pytest.fixture
+def book(db):
+    config.SOPDS_AUTH = True
+    config.SOPDS_ROOT_LIB = DATA
+    cat = Catalog.objects.create(parent=None, cat_name='.', path='.', cat_type=0)
+    return Book.objects.create(
+        filename=FB2, path='.', filesize=os.path.getsize(os.path.join(DATA, FB2)),
+        format='fb2', cat_type=0, docdate='2011', lang='en',
+        title='The Sanctuary Sparrow', search_title='THE SANCTUARY SPARROW',
+        annotation='', avail=2, catalog=cat,
+    )
+
+
+@pytest.fixture
+def account(django_user_model):
+    django_user_model.objects.create_user(username='reader', password='pw')
+    return {'HTTP_AUTHORIZATION': 'Basic %s' % base64.b64encode(b'reader:pw').decode()}
+
+
+def content_routes(book):
+    return [
+        ('cover', reverse('opds:cover', args=[book.id])),
+        ('thumb', reverse('opds:thumb', args=[book.id])),
+        ('read', reverse('opds:read', args=[book.id])),
+        ('download', reverse('opds:download', args=[book.id, 0])),
+        ('convert', reverse('opds:convert', args=[book.id, 'epub'])),
+    ]
+
+
+@pytest.mark.django_db
+def test_anonymous_requests_are_refused(client, book):
+    for name, url in content_routes(book):
+        assert client.get(url).status_code == 401, '%s served an anonymous request' % name
+
+
+@pytest.mark.django_db
+def test_basic_auth_is_accepted(client, book, account):
+    """E-readers cannot carry a session cookie; they re-send Basic auth."""
+    for name in ('cover', 'thumb', 'read', 'download'):
+        url = dict((n, u) for n, u in content_routes(book))[name]
+        assert client.get(url, **account).status_code == 200, '%s rejected Basic auth' % name
+
+
+@pytest.mark.django_db
+def test_a_session_login_is_accepted(client, book, django_user_model):
+    user = django_user_model.objects.create_user(username='web', password='pw')
+    client.force_login(user)
+    for name in ('cover', 'thumb', 'read', 'download'):
+        url = dict((n, u) for n, u in content_routes(book))[name]
+        assert client.get(url, **{}).status_code == 200, '%s rejected a session login' % name
+
+
+@pytest.mark.django_db
+def test_bad_credentials_are_refused(client, book):
+    bad = {'HTTP_AUTHORIZATION': 'Basic %s' % base64.b64encode(b'reader:wrong').decode()}
+    assert client.get(reverse('opds:cover', args=[book.id]), **bad).status_code == 401
+
+
+@pytest.mark.django_db
+def test_everything_is_open_when_auth_is_disabled(client, book):
+    config.SOPDS_AUTH = False
+    for name, url in content_routes(book):
+        if name == 'convert':
+            continue   # needs an external converter binary
+        assert client.get(url).status_code == 200, '%s refused an open catalogue' % name
+
+
+@pytest.mark.django_db
+def test_the_401_comes_before_the_cover_is_extracted(client, book, monkeypatch):
+    """Anonymous traffic must not be able to spend CPU unzipping and parsing
+    books, nor to populate the cover cache."""
+    from opds_catalog import dl
+
+    def fail(*args, **kwargs):
+        raise AssertionError('the book was opened for an unauthenticated request')
+
+    monkeypatch.setattr(dl, 'extract_cover', fail)
+    assert client.get(reverse('opds:cover', args=[book.id])).status_code == 401
+
+
+@pytest.mark.django_db
+def test_the_placeholder_stays_open(client):
+    """The book-less no-cover image carries nothing from the catalogue, and
+    templates use it as a plain default image."""
+    config.SOPDS_AUTH = True
+    assert client.get(reverse('opds:covertmpl')).status_code == 200

--- a/opds_catalog/tests/test_cover_cache.py
+++ b/opds_catalog/tests/test_cover_cache.py
@@ -29,6 +29,9 @@ def library(db, tmp_path):
     # one test rewrites it.
     shutil.copy(os.path.join(DATA, FB2), tmp_path / FB2)
     config.SOPDS_ROOT_LIB = str(tmp_path)
+    # This module is about caching, not access control; the cover routes answer
+    # 401 before any of it when SOPDS_AUTH is on (see test_content_auth.py).
+    config.SOPDS_AUTH = False
     cat = Catalog.objects.create(parent=None, cat_name='.', path='.', cat_type=0)
     return Book.objects.create(
         filename=FB2, path='.', filesize=os.path.getsize(tmp_path / FB2),

--- a/opds_catalog/tests/test_dl_404.py
+++ b/opds_catalog/tests/test_dl_404.py
@@ -6,8 +6,19 @@ get_object_or_404.
 """
 import pytest
 from django.urls import reverse
+from constance import config
 
 MISSING_ID = 999999
+
+
+@pytest.fixture
+def signed_in(client, django_user_model, db):
+    # These routes serve catalogue content and answer 401 before they ever look
+    # the book up, so the caller has to be authenticated for a 404 to be what
+    # the test is actually measuring.
+    config.SOPDS_AUTH = True
+    client.force_login(django_user_model.objects.create_user(username='dl404', password='pw'))
+    return client
 
 
 @pytest.mark.django_db
@@ -17,6 +28,6 @@ MISSING_ID = 999999
     ("opds:read", [MISSING_ID]),
     ("opds:cover", [MISSING_ID]),
 ])
-def test_missing_book_returns_404(client, name, args):
-    resp = client.get(reverse(name, args=args))
+def test_missing_book_returns_404(signed_in, name, args):
+    resp = signed_in.get(reverse(name, args=args))
     assert resp.status_code == 404


### PR DESCRIPTION
With `SOPDS_AUTH` on, the OPDS feeds and `Download` answered 401 to an anonymous request, so the catalogue *looked* closed. Four routes were not.

| route | before | after |
|---|---|---|
| `/opds/read/<id>/` | **200** | 401 |
| `/opds/cover/<id>/` | **200** | 401 |
| `/opds/thumb/<id>/` | **200** | 401 |
| `/opds/convert/<id>/…` | **200** | 401 |
| `/opds/download/…`, feeds | 401 | 401 |

`/opds/read/` is the serious one: it renders the whole book to HTML, so the entire library was readable by anyone who knew an id — and ids are sequential. The cover routes leaked cover art, which normally carries the title and author.

## Changes

- `Download`'s inline check becomes `require_catalog_access`, shared by all five routes. It accepts a session login **or** OPDS Basic auth, because e-readers fetch covers with the same credentials they use for the feed and cannot carry a session cookie.
- On the cover routes the guard sits **outside** the ETag and the cache, so an unauthenticated request is turned away before it can spend CPU unzipping and parsing a book, or populate the cover cache.
- The book-less no-cover placeholder (`/opds/thumb/`) stays open: it carries nothing from the catalogue and templates use it as a plain default image.

## Tests

`opds_catalog/tests/test_content_auth.py`: anonymous refusal across all five routes, Basic auth and session login both accepted, bad credentials refused, everything open when `SOPDS_AUTH` is off, and the 401 landing before extraction.

Two existing modules had been relying on covers being open — and on `SOPDS_AUTH` leaking in from whichever test ran before them. Both now state what they need.