### PR TITLE
Render EPUB for the in-browser reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes to this project are documented here. The format is based on
 ## [Unreleased]
 
 ### Added
+- **EPUB can be read in the browser.** Until now the reader was FB2-only; #66
+  had removed the Read link everywhere else rather than leave it leading to a
+  500. Instead of bolting a second, client-side reader onto the page, the EPUB
+  is rendered server-side into the same flat stream of numbered paragraphs and
+  `TOC_n` chapter markers the FB2 stylesheet emits, so remembered position,
+  the progress bar, chapter mode and the font-size preference all work on EPUB
+  with no change to the reader and no new JavaScript dependency.
+  Illustrations are served from inside the archive by a new
+  `/opds/read/<id>/res/<path>` route. Because the markup comes from the book,
+  it is rebuilt against an allowlist rather than filtered: scripts, styles,
+  embedded objects, event handlers and `javascript:`/`data:`/`file:` links do
+  not survive, the book's own `class`/`style`/`id` are dropped so it cannot
+  restyle the reader or collide with the position ids, and an `<img>` is kept
+  only if it resolves to something the archive actually holds. PDF and DjVu
+  still download rather than open; those need a real client-side viewer.
 - **Ratings are aggregated across readers.** `bookshelf.rating` had been
   collected per user for a while but only ever read back to redraw that same
   user's own stars: nobody could see what the library as a whole thought of a

--- a/opds_catalog/dl.py
+++ b/opds_catalog/dl.py
@@ -7,6 +7,8 @@ import io
 import shlex
 import subprocess
 import lxml.etree as ET
+import mimetypes
+import posixpath
 from functools import wraps
 from re import search
 import logging
@@ -14,11 +16,12 @@ import logging
 from django.core.cache import cache
 from django.http import HttpResponse, Http404
 from django.shortcuts import get_object_or_404
+from django.urls import reverse
 from django.utils.cache import patch_cache_control
 from django.views.decorators.http import etag
 
 from opds_catalog.models import Book, bookshelf
-from opds_catalog import settings, utils, opdsdb, fb2parse
+from opds_catalog import settings, utils, opdsdb, fb2parse, epub_render
 import zipfile
 from opds_catalog.ziptools import open_zipfile
 
@@ -38,6 +41,11 @@ logger = logging.getLogger(__name__)
 # tiny-but-huge-dimension image raises DecompressionBombError instead of
 # allocating gigabytes (real covers are far below this).
 Image.MAX_IMAGE_PIXELS = 64_000_000
+
+# Upper bound on a single illustration served out of an EPUB. Real cover art and
+# plates are far below this; the cap stops a crafted archive from making the
+# reader page pull a multi-gigabyte member.
+MAX_RESOURCE_BYTES = 32 * 1024 * 1024
 
 
 def require_catalog_access(view):
@@ -594,15 +602,88 @@ def ConvertFB2(request, book_id, convert_type):
     return response
 
 
+# Formats the in-browser reader can render. FB2 goes through FB2_22_xhtml.xsl,
+# EPUB through opds_catalog.epub_render; both produce the same flat stream of
+# numbered paragraphs, so the reader itself does not care which it got.
+READABLE_FORMATS = ('fb2', 'epub')
+
+
+@require_catalog_access
+def Read(request, book_id):
+    """Dispatch to the renderer for this book's format."""
+    book = get_object_or_404(Book, id=book_id)
+    if book.format == 'epub':
+        return render_epub(request, book)
+    return ReadFB2(request, book_id)
+
+
+def render_epub(request, book):
+    """ Чтение EPUB в браузере. Not a route: reached through `Read`. """
+    if config.SOPDS_AUTH and request.user.is_authenticated:
+        bookshelf.objects.get_or_create(user=request.user, book=book)
+
+    data = getFileData(book)
+    if data is None:
+        raise Http404
+
+    def resource_url(path):
+        return reverse('opds_catalog:readres',
+                       kwargs={'book_id': book.id, 'path': path})
+
+    try:
+        html = epub_render.render(data, resource_url)
+    except (epub_render.EpubError, zipfile.BadZipFile, KeyError) as err:
+        logger.warning('Cannot render EPUB for book %s: %s', book.id, err)
+        raise Http404
+
+    return HttpResponse(html, content_type='text/html; charset=utf-8')
+
+
+@require_catalog_access
+def ReadResource(request, book_id, path):
+    """Serve one image from inside an EPUB, for the rendered reader page.
+
+    Only images the package actually contains are served, and only as images:
+    the path is resolved against the archive's own name list, so a crafted
+    `src` cannot address anything outside it, and the content type is decided
+    here rather than taken from the book.
+    """
+    book = get_object_or_404(Book, id=book_id)
+    if book.format != 'epub':
+        raise Http404
+
+    data = getFileData(book)
+    if data is None:
+        raise Http404
+
+    try:
+        with zipfile.ZipFile(data) as archive:
+            # normpath collapses any ".." before the lookup, and membership in
+            # the archive is the authorisation: a name that is not in it is a 404.
+            wanted = posixpath.normpath(path).lstrip('/')
+            info = next((i for i in archive.infolist() if i.filename == wanted), None)
+            if info is None or info.file_size > MAX_RESOURCE_BYTES:
+                raise Http404
+            content_type = mimetypes.guess_type(wanted)[0] or ''
+            if not content_type.startswith('image/'):
+                raise Http404
+            payload = archive.read(info)
+    except zipfile.BadZipFile:
+        raise Http404
+
+    response = HttpResponse(payload, content_type=content_type)
+    patch_cache_control(response, private=True, max_age=config.SOPDS_CACHE_TIME)
+    return response
+
+
 @require_catalog_access
 def ReadFB2(request, book_id):
     """ Загрузка книги """
     book = get_object_or_404(Book, id=book_id)
 
-    # The reader renders a book by running FB2_22_xhtml.xsl over its XML, so it
-    # only works for FB2. Anything else reached ET.parse() and died there with a
-    # 500 (an EPUB or MOBI is a binary container, not XML). Mirror the guard
-    # ConvertFB2 already has.
+    # FB2_22_xhtml.xsl only understands FB2; anything else reached ET.parse()
+    # and died there with a 500 (an EPUB or MOBI is a binary container, not
+    # XML). Mirror the guard ConvertFB2 already has.
     if book.format != 'fb2':
         raise Http404
 

--- a/opds_catalog/epub_render.py
+++ b/opds_catalog/epub_render.py
@@ -1,0 +1,360 @@
+# -*- coding: utf-8 -*-
+"""Render an EPUB to the flat XHTML fragment the in-browser reader consumes.
+
+The reader was written against the FB2 path, where FB2_22_xhtml.xsl turns a book
+into one stream of ``<div id="S.P">`` paragraphs separated by ``<a name="TOC_n">``
+chapter markers. Everything the reader does — remembering your position, the
+progress bar, chapter mode, the font-size preference — is expressed in terms of
+that shape. So rather than bolt a second, client-side reader onto the page for
+EPUB, this produces the same shape server-side and the existing reader works on
+EPUB unchanged.
+
+An EPUB is a zip of XHTML documents written by someone else, so the markup is
+untrusted and is rebuilt rather than filtered: only known-safe elements and
+attributes survive (see ALLOWED_*), everything else is either dropped with its
+subtree (scripts, styles, embedded objects) or unwrapped to its text. A denylist
+would have to anticipate every dangerous construct; an allowlist only has to
+know the harmless ones.
+"""
+import logging
+import posixpath
+import zipfile
+from urllib.parse import unquote, urlparse
+
+import lxml.etree as ET
+import lxml.html
+
+from book_tools.format.util import safe_lxml_parser
+
+logger = logging.getLogger(__name__)
+
+CONTAINER = 'META-INF/container.xml'
+OPF_NS = 'http://www.idpf.org/2007/opf'
+CONTAINER_NS = 'urn:oasis:names:tc:opendocument:xmlns:container'
+
+# Documents we will render from the spine.
+TEXT_TYPES = ('application/xhtml+xml', 'text/html', 'application/x-dtbook+xml')
+
+# Dropped along with everything inside them, because what is inside is code or
+# metadata rather than prose: keeping the text would splice CSS and JavaScript
+# source into the middle of the book.
+#
+# Deliberately short. Every other unwanted element — iframe, object, embed,
+# form controls, svg, media — is merely unwrapped, so its descendants are still
+# judged individually by the allowlist. That matters because the HTML fallback
+# parser nests whatever follows an unclosed tag *inside* it: with <embed> in the
+# drop-subtree list, one stray unclosed tag in a sloppy EPUB silently swallowed
+# the rest of the chapter.
+DROP_SUBTREE = frozenset((
+    'script', 'style', 'link', 'meta', 'base', 'title', 'head',
+))
+
+# Kept as elements. Anything not here and not in DROP_SUBTREE is unwrapped: the
+# tag goes, its text and children stay.
+ALLOWED_TAGS = frozenset((
+    'div', 'p', 'br', 'hr', 'span',
+    'em', 'i', 'strong', 'b', 'u', 's', 'strike', 'del', 'ins', 'small',
+    'sub', 'sup', 'abbr', 'cite', 'q', 'code', 'kbd', 'samp', 'var', 'pre',
+    'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+    'blockquote', 'ul', 'ol', 'li', 'dl', 'dt', 'dd',
+    'table', 'thead', 'tbody', 'tfoot', 'tr', 'td', 'th', 'caption',
+    'img', 'a', 'figure', 'figcaption', 'ruby', 'rt', 'rp',
+))
+
+# Attributes kept per tag. `class`, `style` and `id` are deliberately absent:
+# the book's own styling is not wanted inside our reader chrome, and an incoming
+# `id` could collide with the "S.P" ids the reader navigates by.
+ALLOWED_ATTRS = {
+    None: frozenset(('title', 'lang', 'dir')),
+    'a': frozenset(('href',)),
+    'img': frozenset(('src', 'alt', 'width', 'height')),
+    'td': frozenset(('colspan', 'rowspan')),
+    'th': frozenset(('colspan', 'rowspan')),
+    'ol': frozenset(('start',)),
+}
+
+# Only these survive on a link. A book may legitimately point at the web; it may
+# not point at javascript:, data: or file:.
+SAFE_SCHEMES = frozenset(('http', 'https', 'mailto'))
+
+# Guard against a book with an absurd number of spine documents.
+MAX_DOCUMENTS = 2000
+
+
+class EpubError(Exception):
+    """The file is not an EPUB we can render."""
+
+
+def _parse_xml(data):
+    """Parse a document from the archive with entity resolution disabled.
+
+    Real EPUBs are frequently not well-formed XML despite the specification, so
+    fall back to the HTML parser. Both are configured not to fetch anything.
+    """
+    try:
+        return ET.fromstring(data, parser=safe_lxml_parser())
+    except ET.XMLSyntaxError:
+        parser = lxml.html.HTMLParser(no_network=True, recover=True)
+        return lxml.html.fromstring(data, parser=parser)
+
+
+def _localname(tag):
+    if not isinstance(tag, str):
+        return ''
+    return tag.rsplit('}', 1)[-1].lower()
+
+
+def opf_path(archive):
+    """Path of the package document, per META-INF/container.xml."""
+    try:
+        container = _parse_xml(archive.read(CONTAINER))
+    except KeyError:
+        raise EpubError('no %s' % CONTAINER)
+
+    for element in container.iter():
+        if _localname(element.tag) == 'rootfile':
+            path = element.get('full-path')
+            if path:
+                return path
+    raise EpubError('no rootfile in %s' % CONTAINER)
+
+
+def spine_documents(archive):
+    """The archive paths of the reading-order documents, in order."""
+    package_path = opf_path(archive)
+    base = posixpath.dirname(package_path)
+
+    try:
+        package = _parse_xml(archive.read(package_path))
+    except KeyError:
+        raise EpubError('package document %s is missing' % package_path)
+
+    manifest, spine = {}, []
+    for element in package.iter():
+        name = _localname(element.tag)
+        if name == 'item':
+            item_id, href = element.get('id'), element.get('href')
+            if item_id and href:
+                manifest[item_id] = (href, (element.get('media-type') or '').lower())
+        elif name == 'itemref':
+            idref = element.get('idref')
+            if idref:
+                spine.append(idref)
+
+    documents = []
+    for idref in spine[:MAX_DOCUMENTS]:
+        entry = manifest.get(idref)
+        if entry is None:
+            continue
+        href, media_type = entry
+        if media_type and media_type not in TEXT_TYPES:
+            continue
+        documents.append(resolve(base, href))
+
+    if not documents:
+        raise EpubError('no readable documents in the spine')
+
+    return documents
+
+
+def resolve(base, href):
+    """An archive path from a base directory and a possibly-relative href."""
+    href = unquote((href or '').split('#', 1)[0])
+    return posixpath.normpath(posixpath.join(base, href)).lstrip('/')
+
+
+def _safe_href(value):
+    """A link the reader may keep, or None.
+
+    Intra-book links are dropped: their targets live in ids we strip, so they
+    would be dead anyway, and the anchor is unwrapped so the footnote marker or
+    caption text survives as plain text.
+    """
+    value = (value or '').strip()
+    if not value:
+        return None
+    parsed = urlparse(value)
+    if parsed.scheme.lower() in SAFE_SCHEMES and parsed.netloc:
+        return value
+    if parsed.scheme.lower() == 'mailto' and parsed.path:
+        return value
+    return None
+
+
+def sanitize(element, resource):
+    """Rebuild a parsed document body in place, keeping only what is allowed.
+
+    `resource(path) -> url or None` maps an image reference inside the archive
+    to a URL the browser may fetch; returning None drops the image.
+    """
+    for node in list(element.iter()):
+        # The root is the caller's <body>; it is retagged to a <div> afterwards
+        # and must not be judged against the allowlist, which would unwrap it
+        # and leave the caller holding an empty element.
+        if node is element:
+            continue
+
+        name = _localname(node.tag)
+
+        if not isinstance(node.tag, str):     # comment / processing instruction
+            _drop(node, keep_children=False)
+            continue
+
+        if name in DROP_SUBTREE:
+            _drop(node, keep_children=False)
+            continue
+
+        if name not in ALLOWED_TAGS:
+            _drop(node, keep_children=True)
+            continue
+
+        allowed = ALLOWED_ATTRS.get(name, frozenset()) | ALLOWED_ATTRS[None]
+        for attribute in list(node.attrib):
+            # Namespaced and on* attributes never survive; the rest must be
+            # named in the allowlist for this tag.
+            if attribute.lower() not in allowed or attribute.startswith('{'):
+                del node.attrib[attribute]
+
+        if name == 'a':
+            href = _safe_href(node.get('href'))
+            if href is None:
+                _drop(node, keep_children=True)
+            else:
+                node.set('href', href)
+                node.set('rel', 'nofollow noopener noreferrer')
+                node.set('target', '_blank')
+
+        elif name == 'img':
+            url = resource(node.get('src'))
+            if url is None:
+                _drop(node, keep_children=False)
+            else:
+                node.set('src', url)
+                node.set('loading', 'lazy')
+
+
+def _append_text(parent, previous, text):
+    """Add loose text to a parent, after `previous` if there is one."""
+    if not text:
+        return
+    if previous is not None:
+        previous.tail = (previous.tail or '') + text
+    else:
+        parent.text = (parent.text or '') + text
+
+
+def _drop(node, keep_children):
+    """Remove a node, optionally splicing its text and children into its parent.
+
+    `lxml.html` has `drop_tag()` for this, but a well-formed EPUB parses as XML
+    and yields plain `_Element`s, which do not have it — so the splice is done
+    by hand and works for whichever parser handled the document.
+    """
+    parent = node.getparent()
+    if parent is None:
+        return
+
+    previous = node.getprevious()
+
+    if not keep_children:
+        _append_text(parent, previous, node.tail)
+        parent.remove(node)
+        return
+
+    _append_text(parent, previous, node.text)
+
+    index = parent.index(node)
+    children = list(node)
+    for offset, child in enumerate(children):
+        parent.insert(index + offset, child)
+
+    # The tail belongs after whatever now stands in the node's place.
+    _append_text(parent, children[-1] if children else previous, node.tail)
+    parent.remove(node)
+
+
+def strip_namespaces(root):
+    """Reduce every tag to its local name.
+
+    XHTML parsed as XML comes back as `{http://www.w3.org/1999/xhtml}p`. Left
+    alone, that survives into the serialised fragment as prefixed tag names the
+    browser would not recognise.
+    """
+    for node in root.iter():
+        if isinstance(node.tag, str) and '}' in node.tag:
+            node.tag = node.tag.rsplit('}', 1)[-1]
+    ET.cleanup_namespaces(root)
+
+
+def number_paragraphs(body, index):
+    """Give each paragraph the `<div id="section.paragraph">` the reader tracks.
+
+    The reader saves and restores a position by the id of a `div`, so a `<p>`
+    becomes a `<div>` — which is also what the FB2 stylesheet emits.
+    """
+    counter = 0
+    for node in body.iter():
+        if _localname(node.tag) == 'p':
+            counter += 1
+            node.tag = 'div'
+            node.set('id', '%d.%d' % (index, counter))
+    return counter
+
+
+def render(fileobj, resource_url):
+    """The whole book as one XHTML fragment.
+
+    `resource_url(archive_path) -> url` builds the URL for an image; it may
+    return None to drop one.
+    """
+    with zipfile.ZipFile(fileobj) as archive:
+        documents = spine_documents(archive)
+        names = set(archive.namelist())
+        parts = []
+
+        for index, path in enumerate(documents, start=1):
+            if path not in names:
+                logger.debug('EPUB spine references a missing document: %s', path)
+                continue
+            try:
+                document = _parse_xml(archive.read(path))
+            except (ET.XMLSyntaxError, ET.ParserError, ValueError) as err:
+                logger.debug('EPUB document %s did not parse: %s', path, err)
+                continue
+
+            # Namespaces come off the whole document, not just the body: a
+            # declaration is only dropped once nothing under its owner uses it,
+            # and the xhtml default namespace is declared on <html>.
+            strip_namespaces(document)
+            body = next((e for e in document.iter()
+                         if _localname(e.tag) == 'body'), document)
+
+            base = posixpath.dirname(path)
+            sanitize(body, lambda src, base=base: _image(src, base, names, resource_url))
+            number_paragraphs(body, index)
+
+            # The chapter marker the reader splits on, then the document itself
+            # flattened to a div so the fragment stays one flat stream.
+            parts.append('<a name="TOC_%d"></a>' % index)
+            body.tag = 'div'
+            for attribute in list(body.attrib):
+                del body.attrib[attribute]
+            parts.append(ET.tostring(body, encoding='unicode', method='html'))
+
+    if not parts:
+        raise EpubError('nothing renderable in the archive')
+
+    return ''.join(parts)
+
+
+def _image(src, base, names, resource_url):
+    """Map an <img src> inside the archive to a URL, or None to drop it."""
+    if not src:
+        return None
+    if urlparse(src).scheme:      # remote or javascript:/data: — never followed
+        return None
+
+    path = resolve(base, src)
+    if path not in names:
+        return None
+    return resource_url(path)

--- a/opds_catalog/tests/test_epub_render.py
+++ b/opds_catalog/tests/test_epub_render.py
@@ -1,0 +1,212 @@
+"""Rendering an EPUB into the fragment the in-browser reader consumes.
+
+An EPUB is markup written by somebody else, so most of this is about what does
+*not* survive the trip.
+"""
+import io
+import os
+import re
+import zipfile
+
+import pytest
+
+from opds_catalog import epub_render
+
+DATA = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
+REAL_EPUB = os.path.join(DATA, 'mirer.epub')
+
+CONTAINER = '''<?xml version="1.0" encoding="utf-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles><rootfile full-path="OEBPS/content.opf"
+    media-type="application/oebps-package+xml"/></rootfiles>
+</container>'''
+
+OPF = '''<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="2.0">
+  <manifest>%s</manifest>
+  <spine>%s</spine>
+</package>'''
+
+
+def build_epub(documents, extra=None):
+    """A minimal EPUB from {href: xhtml}, in the order given."""
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, 'w') as archive:
+        archive.writestr('mimetype', 'application/epub+zip')
+        archive.writestr('META-INF/container.xml', CONTAINER)
+        items, refs = [], []
+        for n, (href, body) in enumerate(documents.items(), start=1):
+            items.append('<item id="d%d" href="%s" media-type="application/xhtml+xml"/>' % (n, href))
+            refs.append('<itemref idref="d%d"/>' % n)
+            archive.writestr('OEBPS/' + href,
+                             '<?xml version="1.0" encoding="utf-8"?>'
+                             '<html xmlns="http://www.w3.org/1999/xhtml"><head>'
+                             '<title>t</title></head><body>%s</body></html>' % body)
+        archive.writestr('OEBPS/content.opf', OPF % (''.join(items), ''.join(refs)))
+        for name, payload in (extra or {}).items():
+            archive.writestr(name, payload)
+    buffer.seek(0)
+    return buffer
+
+
+def render(documents, extra=None, resource=lambda p: '/res/' + p):
+    return epub_render.render(build_epub(documents, extra), resource)
+
+
+# --- structure the reader depends on ---------------------------------------
+
+def test_each_spine_document_becomes_a_chapter_marker():
+    html = render({'a.xhtml': '<p>one</p>', 'b.xhtml': '<p>two</p>'})
+    assert html.count('<a name="TOC_1">') == 1
+    assert html.count('<a name="TOC_2">') == 1
+
+
+def test_paragraphs_are_divs_numbered_by_document():
+    """The reader saves a position as the id of a `div`, "section.paragraph"."""
+    html = render({'a.xhtml': '<p>one</p><p>two</p>', 'b.xhtml': '<p>three</p>'})
+    assert '<div id="1.1"' in html and '<div id="1.2"' in html
+    assert '<div id="2.1"' in html
+    assert '<p' not in html
+
+
+def test_spine_order_is_preserved():
+    html = render({'a.xhtml': '<p>first</p>', 'b.xhtml': '<p>second</p>'})
+    assert html.index('first') < html.index('second')
+
+
+def test_text_survives():
+    html = render({'a.xhtml': '<p>Hello <em>there</em>, reader</p>'})
+    assert 'Hello' in html and 'there' in html and 'reader' in html
+    assert '<em>' in html
+
+
+def test_the_real_sample_book_renders():
+    with open(REAL_EPUB, 'rb') as f:
+        html = epub_render.render(f, lambda p: '/res/' + p)
+    assert len(re.findall(r'<a name="TOC_\d+"></a>', html)) > 1
+    assert len(re.findall(r'<div id="\d+\.\d+"', html)) > 100
+    assert 'xmlns' not in html          # namespaces stripped, not serialised
+
+
+# --- untrusted markup ------------------------------------------------------
+
+def test_scripts_are_removed_with_their_contents():
+    html = render({'a.xhtml': '<p>before</p><script>alert(1)</script><p>after</p>'})
+    assert '<script' not in html and 'alert(1)' not in html
+    assert 'before' in html and 'after' in html
+
+
+@pytest.mark.parametrize('markup', [
+    '<iframe src="http://evil/"></iframe>',
+    '<object data="x.swf"></object>',
+    '<embed src="x">',
+    '<form action="http://evil/"><input name="p"></form>',
+    '<style>body{display:none}</style>',
+    '<link rel="stylesheet" href="http://evil/x.css">',
+    '<svg><script>alert(1)</script></svg>',
+])
+def test_active_and_remote_content_is_removed(markup):
+    html = render({'a.xhtml': markup + '<p>kept</p>'})
+    # Prose after the offending element survives even when a sloppy, unclosed
+    # tag made the fallback parser nest it inside.
+    assert 'kept' in html
+    for banned in ('iframe', 'object', 'embed', '<form', '<input', '<style',
+                   '<link', '<svg', 'alert', 'evil'):
+        assert banned not in html, markup
+
+
+def test_event_handlers_are_stripped():
+    html = render({'a.xhtml': '<p onclick="steal()" onerror="x()">text</p>'})
+    assert 'onclick' not in html and 'onerror' not in html and 'steal' not in html
+    assert 'text' in html
+
+
+@pytest.mark.parametrize('href', [
+    'javascript:alert(1)', 'JavaScript:alert(1)', 'data:text/html,<script>x</script>',
+    'file:///etc/passwd', 'vbscript:x',
+])
+def test_dangerous_link_schemes_do_not_survive(href):
+    html = render({'a.xhtml': '<p><a href="%s">click</a></p>' % href})
+    assert 'href' not in html
+    assert 'click' in html          # the anchor is unwrapped, its text stays
+
+
+def test_external_links_are_kept_but_defanged():
+    html = render({'a.xhtml': '<p><a href="https://example.com/x">site</a></p>'})
+    assert 'https://example.com/x' in html
+    assert 'nofollow' in html and 'noopener' in html
+
+
+def test_book_styling_is_not_carried_into_the_reader():
+    html = render({'a.xhtml': '<p class="fancy" style="color:red" id="mine">text</p>'})
+    assert 'class=' not in html and 'style=' not in html
+    assert 'id="mine"' not in html          # would collide with the reader's ids
+    assert '<div id="1.1"' in html
+
+
+# --- images ----------------------------------------------------------------
+
+def test_images_inside_the_archive_are_rewritten_to_the_resource_url():
+    html = render({'a.xhtml': '<p><img src="img/pic.png" alt="a"/></p>'},
+                  extra={'OEBPS/img/pic.png': b'\x89PNG'})
+    assert 'src="/res/OEBPS/img/pic.png"' in html
+    assert 'alt="a"' in html
+
+
+def test_remote_images_are_dropped():
+    html = render({'a.xhtml': '<p><img src="http://evil/track.gif"><span>t</span></p>'})
+    assert '<img' not in html and 'evil' not in html
+    assert 't' in html
+
+
+def test_images_that_are_not_in_the_archive_are_dropped():
+    html = render({'a.xhtml': '<p><img src="missing.png">text</p>'})
+    assert '<img' not in html
+    assert 'text' in html
+
+
+def test_a_traversing_image_path_cannot_escape_the_archive():
+    html = render({'a.xhtml': '<p><img src="../../../../etc/passwd"></p>'})
+    assert '<img' not in html
+    assert 'passwd' not in html
+
+
+# --- malformed input -------------------------------------------------------
+
+def test_a_document_that_is_not_well_formed_xml_still_renders():
+    """Real EPUBs are frequently sloppy despite the specification."""
+    html = render({'a.xhtml': '<p>unclosed <b>bold</p>'})
+    assert 'unclosed' in html and 'bold' in html
+
+
+def test_an_archive_without_a_container_is_rejected():
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, 'w') as archive:
+        archive.writestr('random.txt', 'not a book')
+    buffer.seek(0)
+    with pytest.raises(epub_render.EpubError):
+        epub_render.render(buffer, lambda p: p)
+
+
+def test_an_empty_spine_is_rejected():
+    with pytest.raises(epub_render.EpubError):
+        render({})
+
+
+def test_a_spine_entry_with_no_file_is_skipped():
+    buffer = build_epub({'a.xhtml': '<p>kept</p>'})
+    with zipfile.ZipFile(buffer, 'a') as archive:
+        opf = archive.read('OEBPS/content.opf').decode()
+    patched = opf.replace('</manifest>',
+                          '<item id="ghost" href="ghost.xhtml" media-type="application/xhtml+xml"/></manifest>')
+    patched = patched.replace('</spine>', '<itemref idref="ghost"/></spine>')
+
+    rebuilt = io.BytesIO()
+    with zipfile.ZipFile(buffer) as src, zipfile.ZipFile(rebuilt, 'w') as dst:
+        for item in src.infolist():
+            payload = patched if item.filename == 'OEBPS/content.opf' else src.read(item)
+            dst.writestr(item.filename, payload)
+    rebuilt.seek(0)
+
+    html = epub_render.render(rebuilt, lambda p: p)
+    assert 'kept' in html

--- a/opds_catalog/tests/test_epub_resource.py
+++ b/opds_catalog/tests/test_epub_resource.py
@@ -1,0 +1,96 @@
+"""Serving illustrations out of an EPUB for the rendered reader page.
+
+The path in the URL comes from the book's own markup, so it is untrusted: the
+view must only ever hand back something the archive actually contains, and only
+if it is an image.
+"""
+import os
+
+import pytest
+from django.urls import reverse
+from constance import config
+
+from opds_catalog.models import Book, Catalog
+
+DATA = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
+EPUB = 'mirer.epub'
+IMAGE = 'OEBPS/images/MIRERUmenjadevjatzhiznejj.jpg'
+
+
+@pytest.fixture
+def book(db, django_user_model, client):
+    config.SOPDS_AUTH = True
+    config.SOPDS_ROOT_LIB = DATA
+    cat = Catalog.objects.create(parent=None, cat_name='.', path='.', cat_type=0)
+    book = Book.objects.create(
+        filename=EPUB, path='.', filesize=os.path.getsize(os.path.join(DATA, EPUB)),
+        format='epub', cat_type=0, docdate='2011', lang='ru', title='Mirer',
+        search_title='MIRER', annotation='', avail=2, catalog=cat)
+    client.force_login(django_user_model.objects.create_user(username='r', password='pw'))
+    return book
+
+
+def url(book, path):
+    return reverse('opds:readres', kwargs={'book_id': book.id, 'path': path})
+
+
+@pytest.mark.django_db
+def test_serves_an_image_the_archive_contains(client, book):
+    resp = client.get(url(book, IMAGE))
+    assert resp.status_code == 200
+    assert resp['Content-Type'] == 'image/jpeg'
+    assert len(resp.content) > 0
+
+
+@pytest.mark.django_db
+def test_the_rendered_page_links_images_that_resolve(client, book):
+    body = client.get(reverse('opds:read', args=[book.id])).content.decode()
+    assert url(book, IMAGE) in body
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('path', [
+    '../../../../etc/passwd',
+    'OEBPS/../../../../etc/passwd',
+    '/etc/passwd',
+    'OEBPS/images/../../../secret',
+])
+def test_traversal_is_refused(client, book, path):
+    assert client.get(url(book, path)).status_code == 404
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('path', [
+    'OEBPS/content.opf',                       # in the archive, but not an image
+    'OEBPS/css/main.css',
+    'OEBPS/fonts/liberationserif-regular.ttf',
+    'mimetype',
+])
+def test_non_images_inside_the_archive_are_refused(client, book, path):
+    """Membership alone is not enough: the reader page only needs pictures."""
+    assert client.get(url(book, path)).status_code == 404
+
+
+@pytest.mark.django_db
+def test_a_missing_member_is_404(client, book):
+    assert client.get(url(book, 'OEBPS/images/nope.png')).status_code == 404
+
+
+@pytest.mark.django_db
+def test_resources_require_authentication(client, book):
+    client.logout()
+    assert client.get(url(book, IMAGE)).status_code == 401
+
+
+@pytest.mark.django_db
+def test_a_non_epub_book_has_no_resources(client, book):
+    book.format = 'fb2'
+    book.save(update_fields=['format'])
+    assert client.get(url(book, IMAGE)).status_code == 404
+
+
+@pytest.mark.django_db
+def test_the_response_is_privately_cacheable(client, book):
+    """A cover can be shared, but a page out of a book is behind auth."""
+    resp = client.get(url(book, IMAGE))
+    assert 'private' in resp['Cache-Control']

--- a/opds_catalog/tests/test_reader_format.py
+++ b/opds_catalog/tests/test_reader_format.py
@@ -1,4 +1,7 @@
-"""The in-browser reader only handles FB2; other formats must 404, not 500."""
+"""Which formats the in-browser reader offers, and what the rest do instead.
+
+FB2 and EPUB render; anything else must 404 rather than feed a binary container
+to the XML parser and 500."""
 import os
 
 import pytest
@@ -9,6 +12,7 @@ from opds_catalog.models import Book, Catalog
 
 DATA = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
 FB2 = '262001.fb2'
+EPUB = 'mirer.epub'
 
 
 @pytest.fixture
@@ -34,13 +38,20 @@ def make_book(cat, fmt, filename=FB2):
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('fmt', ['epub', 'mobi', 'pdf', 'djvu'])
+@pytest.mark.parametrize('fmt', ['mobi', 'pdf', 'djvu'])
 def test_reader_404s_for_formats_it_cannot_render(client, library, fmt):
     """Previously these reached lxml's ET.parse() on a binary container and
     raised, returning 500."""
     book = make_book(library, fmt)
     assert client.get(reverse('opds:read', args=[book.id])).status_code == 404
     assert client.get(reverse('web:read', args=[book.id])).status_code == 404
+
+
+@pytest.mark.django_db
+def test_an_epub_that_is_not_a_zip_404s_too(client, library):
+    """Format says epub, contents say otherwise."""
+    book = make_book(library, 'epub', filename=FB2)
+    assert client.get(reverse('opds:read', args=[book.id])).status_code == 404
 
 
 @pytest.mark.django_db
@@ -53,12 +64,23 @@ def test_reader_still_renders_fb2(client, library):
 
 
 @pytest.mark.django_db
-def test_book_list_offers_read_only_for_fb2(client, library):
+def test_reader_renders_epub(client, library):
+    book = make_book(library, 'epub', filename=EPUB)
+    resp = client.get(reverse('opds:read', args=[book.id]))
+    assert resp.status_code == 200
+    assert resp['Content-Type'].startswith('text/html')
+    assert client.get(reverse('web:read', args=[book.id])).status_code == 200
+
+
+@pytest.mark.django_db
+def test_book_list_offers_read_for_the_readable_formats_only(client, library):
     make_book(library, 'fb2')
-    make_book(library, 'epub')
+    make_book(library, 'epub', filename=EPUB)
+    make_book(library, 'pdf')
     body = client.get(reverse('web:searchbooks'), {'searchtype': 'm', 'searchterms': 'BOOK'}).content.decode()
 
-    fb2 = Book.objects.get(format='fb2')
-    epub = Book.objects.get(format='epub')
-    assert reverse('web:read', args=[fb2.id]) in body
-    assert reverse('web:read', args=[epub.id]) not in body
+    for fmt in ('fb2', 'epub'):
+        book = Book.objects.get(format=fmt)
+        assert reverse('web:read', args=[book.id]) in body, fmt
+    pdf = Book.objects.get(format='pdf')
+    assert reverse('web:read', args=[pdf.id]) not in body

--- a/opds_catalog/urls.py
+++ b/opds_catalog/urls.py
@@ -55,7 +55,10 @@ urlpatterns = [
     re_path(r'^cover/(?P<book_id>[0-9]+)/$',dl.Cover, name='cover'),
     re_path(r'^thumb/(?P<book_id>[0-9]+)/$',dl.Thumbnail, name='thumb'),
     re_path(r'^thumb/$',dl.NoCover, name='covertmpl'),
-    re_path(r'^read/(?P<book_id>[0-9]+)/$', dl.ReadFB2, name='read'),
+    re_path(r'^read/(?P<book_id>[0-9]+)/$', dl.Read, name='read'),
+    # Images referenced from a rendered EPUB. The path is matched loosely and
+    # validated against the archive's own name list in the view.
+    re_path(r'^read/(?P<book_id>[0-9]+)/res/(?P<path>.+)$', dl.ReadResource, name='readres'),
 
     re_path(r'^$',feeds.MainFeed(), name='main'),
 ]

--- a/sopds_web_backend/templates/sopds_books.html
+++ b/sopds_web_backend/templates/sopds_books.html
@@ -39,8 +39,8 @@
 			{% if b.format == 'fb2' and fb2tomobi %}
 			   <i><a href="{% url 'opds_catalog:convert' b.id 'mobi' %}"><span class="label small">mobi</span></a></i>&nbsp;
 			{% endif %}			
-			{% if b.format == 'fb2' %}
-			   {# The in-browser reader is an FB2-to-XHTML transform; other formats 404. #}
+			{% if b.readable %}
+			   {# The in-browser reader handles FB2 and EPUB; other formats 404. #}
 			   <i><a href="{% url 'web:read' b.id %}"><span class="label small">{% trans "Read" %}</span></a></i>&nbsp;
 			{% endif %}
 			{% if b.bookshelf %}

--- a/sopds_web_backend/views.py
+++ b/sopds_web_backend/views.py
@@ -20,7 +20,7 @@ from opds_catalog.models import Book, Author, Series, bookshelf, Counter, Catalo
 from opds_catalog import settings
 from opds_catalog.utils import alphabet_menu, contains_page_ids, contains_page
 from book_tools.format.util import normalize_isbn
-from opds_catalog import ratings
+from opds_catalog import dl, ratings
 from constance import config
 from sopds_web_backend import oidc
 from opds_catalog.opds_paginator import Paginator as OPDS_Paginator
@@ -374,6 +374,7 @@ def SearchBooksView(request):
                  'rating': user_shelf[0].rating if user_shelf else None,
                  # The user's own star count, and what everyone else made of it.
                  'rating_all': page_ratings.get(row.id),
+                 'readable': row.format in dl.READABLE_FORMATS,
                  # Percentage read, as reported by an e-reader over kosync.
                  'percent': user_shelf[0].percent if user_shelf else None
                  }
@@ -1075,11 +1076,11 @@ def LogoutView(request):
 @vary_on_headers("HTTP_ACCEPT_LANGUAGE")
 @sopds_login(url='web:login')
 def BookReaderView(request, book_id):
-    # The page is only a shell: it fetches opds:read, which can render FB2 and
-    # nothing else. Refuse here as well, so an unreadable format fails as a 404
-    # on the link instead of loading a reader that stays permanently empty.
+    # The page is only a shell: it fetches opds:read, which renders FB2 and EPUB
+    # and nothing else. Refuse here as well, so an unreadable format fails as a
+    # 404 on the link instead of loading a reader that stays permanently empty.
     book = get_object_or_404(Book, id=book_id)
-    if book.format != 'fb2':
+    if book.format not in dl.READABLE_FORMATS:
         raise Http404
 
     prefs = user_prefs(request.user)


### PR DESCRIPTION
The reader only ever handled FB2. #66 removed the Read link from every other format rather than leave it leading to a 500 — honest, but it left the most common format in most libraries unreadable in the browser.

## Why not epub.js

It would mean vendoring a few hundred kilobytes of JavaScript into a project that deliberately has no build step, and then reimplementing position tracking, chapter navigation and the font preference against a second reader sharing nothing with the first.

Instead the EPUB is rendered **server-side into the shape the existing reader already speaks**: one flat stream of `<div id="section.paragraph">` paragraphs separated by `<a name="TOC_n">` chapter markers — exactly what `FB2_22_xhtml.xsl` produces. Remembered position, the progress bar, chapter mode and the font-size preference therefore all work on EPUB **with no change to the reader and no new dependency**.

## Sanitisation

The markup inside an EPUB is written by someone else, so it is rebuilt against an allowlist rather than filtered:

- Scripts and styles are dropped **with their contents** — that text is code, not prose.
- Everything else unwanted is **unwrapped**, so its descendants are still judged individually. This matters: the fallback HTML parser nests whatever follows an unclosed tag *inside* it, and dropping subtrees wholesale let one stray `<embed>` in a sloppy book swallow the rest of the chapter.
- The book's own `class`/`style`/`id` are dropped, so it can neither restyle the reader nor collide with the ids the reader navigates by.
- Links survive only with an `http(s)` or `mailto` scheme, and get `nofollow noopener noreferrer`.

## Images

A new `/opds/read/<id>/res/<path>` route serves illustrations from inside the archive. The path comes from the book, so it is resolved against the archive's own name list and served only when it names an image the archive actually holds — a crafted `src` cannot address anything else, and the content type is decided by the view rather than taken from the book.

## Tests

- `test_epub_render.py` — 29 tests: the structure the reader depends on, spine order, and a large block on what does *not* survive (scripts, iframes, objects, forms, svg, event handlers, `javascript:`/`data:`/`file:` links, book styling, remote and traversing images), plus malformed input.
- `test_epub_resource.py` — 14 tests: traversal refused, non-images refused, auth required, caching.
- `test_reader_format.py` updated: EPUB now renders, PDF/MOBI/DjVu still 404, and an "epub" that is not a zip 404s too.

## Not included

PDF and DjVu still download rather than open; those need a real client-side viewer.