### PR TITLE
Index kosync digests as part of the scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,13 @@ All notable changes to this project are documented here. The format is based on
   uses `-c`), so the test environment never drifts from production.
 
 ### Fixed
+- The kosync digest index is now refreshed by the scan. It was only ever built
+  by running `sopds_kosync_index` by hand, so every book added afterwards was
+  invisible to the matcher: progress from an e-reader still synced, it just
+  stopped being attributed to a book, and nothing said so. The scanner indexes
+  what it added at the end of each run — idempotent, a no-op when kosync is
+  off, and it swallows its own errors, because failing to index digests must
+  not fail the scan that produced them.
 - The whole web UI returned **500 for every visitor when `SOPDS_AUTH` is off**.
   `sopds_login` lets anonymous visitors through in that configuration — which
   is the point of it — but every view then called `theme_css(request.user)`,

--- a/opds_catalog/management/commands/sopds_scanner.py
+++ b/opds_catalog/management/commands/sopds_scanner.py
@@ -153,6 +153,17 @@ class Command(BaseCommand):
             # atomic on its own), so it is not wrapped in one giant transaction.
             scanner.scan_all()
             Counter.objects.update_known_counters()
+            # Give the books this scan added their KOReader document hashes, so
+            # progress synced from an e-reader can still name a book. Imported
+            # here rather than at module scope to keep the catalog app's import
+            # graph free of the sync app; the call is a no-op when kosync is off
+            # and swallows its own errors, because failing to index digests must
+            # not fail the scan that produced them.
+            from sopds_sync import indexing
+            indexed = indexing.index_new_books()
+            if indexed:
+                self.logger.info('kosync: indexed %d book(s), %d digest(s) added',
+                                 indexed['books'], indexed['added'])
             # Reclaim the dead tuples the avail sweep churns and refresh stats /
             # the visibility map, so post-scan reads keep their Index-Only Scans
             # instead of slowing to tens of seconds until autovacuum catches up.

--- a/sopds_sync/indexing.py
+++ b/sopds_sync/indexing.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+"""Building the BookDigest index that lets kosync progress name a book.
+
+Shared by the `sopds_kosync_index` command and by the scanner, which runs it
+over the newly added books at the end of every scan. Without that second caller
+the index only ever covered the catalogue as it stood when an administrator last
+ran the command by hand, and every book added afterwards silently stopped being
+recognised — the sync kept working, it just no longer knew what was being read.
+"""
+import logging
+
+from opds_catalog import dl, utils
+from opds_catalog.models import Book
+
+from sopds_sync.digest import filename_md5, partial_md5
+from sopds_sync.models import BookDigest
+
+logger = logging.getLogger(__name__)
+
+
+def download_names(book):
+    """Base names this book can carry on a device after an OPDS download.
+
+    `dl.getFileName` returns whichever one SOPDS_TITLE_AS_FILENAME currently
+    selects; index both, because the setting may well have been flipped since
+    the reader fetched the book.
+    """
+    from_title = utils.to_ascii(utils.translit(book.title + '.' + book.format))
+    from_file = utils.to_ascii(utils.translit(book.filename))
+    return {n for n in (from_title, from_file, book.filename) if n}
+
+
+def digests_for(book, skip_binary=False):
+    """`{digest: method}` for one book, or as much of it as we can read."""
+    wanted = {}
+    for name in download_names(book):
+        digest = filename_md5(name)
+        if digest:
+            wanted[digest] = BookDigest.FILENAME
+
+    if skip_binary:
+        return wanted, False
+
+    data = dl.getFileData(book)
+    if data is None:
+        return wanted, True          # unreadable
+    wanted[partial_md5(data)] = BookDigest.BINARY
+    return wanted, False
+
+
+def pending(rebuild=False):
+    """Books that still need indexing."""
+    books = Book.objects.all().order_by('id')
+    if not rebuild:
+        books = books.filter(digests__isnull=True)
+    return books
+
+
+def index(books, dry_run=False, rebuild=False, skip_binary=False,
+          limit=0, on_book=None):
+    """Index `books`, returning a counts dict.
+
+    Idempotent: a book that already carries its digests costs one query and
+    nothing else, which is what makes calling this after every scan cheap.
+    """
+    stats = {'books': 0, 'added': 0, 'unreadable': 0, 'collisions': 0}
+
+    for book in books.iterator(chunk_size=200):
+        if limit and stats['books'] >= limit:
+            break
+        stats['books'] += 1
+
+        wanted, unreadable = digests_for(book, skip_binary=skip_binary)
+        if unreadable:
+            stats['unreadable'] += 1
+
+        if rebuild and not dry_run:
+            BookDigest.objects.filter(book=book).exclude(digest__in=wanted).delete()
+
+        for digest, method in wanted.items():
+            if dry_run:
+                if not BookDigest.objects.filter(digest=digest).exists():
+                    stats['added'] += 1
+                continue
+
+            # `digest` is unique: another book hashing the same way is the same
+            # bytes or the same name, and the first to claim it keeps it.
+            # Attributing progress to one of two identical copies is right
+            # either way; guessing between them is not.
+            row, created = BookDigest.objects.get_or_create(
+                digest=digest, defaults={'book': book, 'method': method})
+            if created:
+                stats['added'] += 1
+            elif row.book_id != book.id:
+                stats['collisions'] += 1
+                logger.debug('Digest %s already claimed by book %s (not %s)',
+                             digest, row.book_id, book.id)
+
+        if on_book is not None:
+            on_book(book, wanted)
+
+    return stats
+
+
+def index_new_books():
+    """Index whatever the last scan added. Safe to call unconditionally.
+
+    Returns the counts dict, or None if the feature is off. Never raises: this
+    runs at the tail of a scan, and a failure to index digests must not be able
+    to fail the scan that produced them.
+    """
+    from constance import config
+
+    if not config.SOPDS_KOSYNC_ENABLE:
+        return None
+
+    try:
+        return index(pending())
+    except Exception:
+        logger.exception('Could not index KOReader digests for the new books')
+        return None

--- a/sopds_sync/management/commands/sopds_kosync_index.py
+++ b/sopds_sync/management/commands/sopds_kosync_index.py
@@ -5,7 +5,10 @@
 #
 # kosync sends only a hash of the copy on the device, so the only way to know
 # which book it is, is to have already worked out what our own files hash to.
-# See sopds_sync.digest for the two hashing methods and their exact definition.
+# See sopds_sync.digest for the two hashing methods and their exact definition,
+# and sopds_sync.indexing for the indexing itself — which the scanner also runs
+# over the books it just added, so a routine scan keeps the index current and
+# this command is only needed for a first run or a --rebuild.
 #
 # Each book gets up to three digests: the partial content md5 (survives a
 # rename), and the file-name md5 for both names a download can end up with —
@@ -16,30 +19,13 @@
 # any size costs a few KiB — but an archived book has to be decompressed up to
 # the last sampled offset, so --skip-binary is there for a large zipped library.
 #
-# Run after a scan: python manage.py sopds_kosync_index [--dry-run] [--limit N]
-import logging
-
+# Run: python manage.py sopds_kosync_index [--dry-run] [--limit N] [--rebuild]
 from django.core.management.base import BaseCommand
 from django.db import close_old_connections
 
-from opds_catalog import dl, utils
-from opds_catalog.models import Book
 from constance import config
 
-from sopds_sync.digest import filename_md5, partial_md5
-from sopds_sync.models import BookDigest
-
-
-def download_names(book):
-    """Base names this book can carry on a device after an OPDS download.
-
-    `dl.getFileName` returns whichever one SOPDS_TITLE_AS_FILENAME currently
-    selects; index both, because the setting may well have been flipped since
-    the reader fetched the book.
-    """
-    from_title = utils.to_ascii(utils.translit(book.title + '.' + book.format))
-    from_file = utils.to_ascii(utils.translit(book.filename))
-    return {n for n in (from_title, from_file, book.filename) if n}
+from sopds_sync import indexing
 
 
 class Command(BaseCommand):
@@ -61,66 +47,30 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         dry_run = options['dry_run']
-        limit = options['limit']
         rebuild = options['rebuild']
-        skip_binary = options['skip_binary']
         verbose = options['verbose']
-        logger = logging.getLogger('')
 
         close_old_connections()
-        qs = Book.objects.all().order_by('id')
-        if not rebuild:
-            qs = qs.filter(digests__isnull=True)
 
-        indexed = added = unreadable = collisions = 0
-        for book in qs.iterator(chunk_size=200):
-            if limit and indexed >= limit:
-                break
-            indexed += 1
-
-            wanted = {name: BookDigest.FILENAME for name in
-                      (filename_md5(n) for n in download_names(book)) if name}
-
-            if not skip_binary:
-                data = dl.getFileData(book)
-                if data is None:
-                    unreadable += 1
-                else:
-                    wanted[partial_md5(data)] = BookDigest.BINARY
-
-            if rebuild and not dry_run:
-                BookDigest.objects.filter(book=book).exclude(digest__in=wanted).delete()
-
-            for digest, method in wanted.items():
-                if dry_run:
-                    if not BookDigest.objects.filter(digest=digest).exists():
-                        added += 1
-                    continue
-
-                # `digest` is unique: another book hashing the same way is the
-                # same bytes or the same name, and the first one to claim it
-                # keeps it. Attributing progress to one of two identical copies
-                # is right either way; guessing between them is not.
-                _row, created = BookDigest.objects.get_or_create(
-                    digest=digest, defaults={'book': book, 'method': method})
-                if created:
-                    added += 1
-                elif _row.book_id != book.id:
-                    collisions += 1
-                    logger.debug('Digest %s already claimed by book %s (not %s)',
-                                 digest, _row.book_id, book.id)
-
+        def report(book, digests):
             if verbose:
                 self.stdout.write('Book %s (%s): %d digest(s)'
-                                  % (book.id, book.filename, len(wanted)))
+                                  % (book.id, book.filename, len(digests)))
+
+        stats = indexing.index(
+            indexing.pending(rebuild=rebuild),
+            dry_run=dry_run, rebuild=rebuild,
+            skip_binary=options['skip_binary'], limit=options['limit'],
+            on_book=report,
+        )
 
         prefix = 'DRY-RUN: ' if dry_run else ''
         self.stdout.write(
             '%skosync index done. Books: %d, digests %s: %d, '
             'files unreadable: %d, already claimed: %d%s'
-            % (prefix, indexed, 'would be added' if dry_run else 'added', added,
-               unreadable, collisions,
-               '' if not skip_binary else ' (content digests skipped)')
+            % (prefix, stats['books'], 'would be added' if dry_run else 'added',
+               stats['added'], stats['unreadable'], stats['collisions'],
+               '' if not options['skip_binary'] else ' (content digests skipped)')
         )
-        if config.SOPDS_KOSYNC_ENABLE is False:
+        if not config.SOPDS_KOSYNC_ENABLE:
             self.stdout.write('Note: SOPDS_KOSYNC_ENABLE is off, so nothing will use this yet.')

--- a/sopds_sync/tests/test_index_on_scan.py
+++ b/sopds_sync/tests/test_index_on_scan.py
@@ -1,0 +1,109 @@
+"""The kosync digest index is kept current by the scan, not only by hand.
+
+Before this the index only covered the catalogue as it stood when someone last
+ran `sopds_kosync_index`. Every book added afterwards was invisible to the
+matcher: the sync kept working, it just no longer knew what was being read — and
+nothing said so.
+"""
+import os
+
+import pytest
+from constance import config
+
+from opds_catalog.models import Book, Catalog
+from sopds_sync import indexing
+from sopds_sync.digest import filename_md5
+from sopds_sync.models import BookDigest
+
+DATA = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__)))), 'opds_catalog', 'tests', 'data')
+FB2 = '262001.fb2'
+EPUB = 'mirer.epub'
+
+
+@pytest.fixture
+def catalogue(db):
+    config.SOPDS_KOSYNC_ENABLE = True
+    config.SOPDS_ROOT_LIB = DATA
+    config.SOPDS_TITLE_AS_FILENAME = True
+    return Catalog.objects.create(parent=None, cat_name='.', path='.', cat_type=0)
+
+
+def add_book(cat, filename, title):
+    return Book.objects.create(
+        filename=filename, path='.', filesize=os.path.getsize(os.path.join(DATA, filename)),
+        format=filename.rsplit('.', 1)[1], cat_type=0, docdate='2011', lang='en',
+        title=title, search_title=title.upper(), annotation='', avail=2, catalog=cat)
+
+
+@pytest.mark.django_db
+def test_new_books_are_indexed(catalogue):
+    book = add_book(catalogue, FB2, 'Sparrow')
+    stats = indexing.index_new_books()
+
+    assert stats['books'] == 1
+    assert BookDigest.objects.filter(book=book).exists()
+    assert indexing.pending().count() == 0
+
+
+@pytest.mark.django_db
+def test_a_second_run_costs_nothing(catalogue):
+    add_book(catalogue, FB2, 'Sparrow')
+    indexing.index_new_books()
+
+    stats = indexing.index_new_books()
+    assert stats == {'books': 0, 'added': 0, 'unreadable': 0, 'collisions': 0}
+
+
+@pytest.mark.django_db
+def test_only_the_books_added_since_last_time_are_touched(catalogue):
+    """The scan calls this every run; it must not re-hash the whole library."""
+    add_book(catalogue, FB2, 'Sparrow')
+    indexing.index_new_books()
+
+    add_book(catalogue, EPUB, 'Mirer')
+    stats = indexing.index_new_books()
+    assert stats['books'] == 1
+
+
+@pytest.mark.django_db
+def test_it_does_nothing_while_kosync_is_disabled(catalogue):
+    config.SOPDS_KOSYNC_ENABLE = False
+    add_book(catalogue, FB2, 'Sparrow')
+
+    assert indexing.index_new_books() is None
+    assert not BookDigest.objects.exists()
+
+
+@pytest.mark.django_db
+def test_an_indexing_failure_cannot_fail_the_scan(catalogue, monkeypatch):
+    """This runs at the tail of a scan; the scan has already committed."""
+    add_book(catalogue, FB2, 'Sparrow')
+
+    def boom(*args, **kwargs):
+        raise RuntimeError('disk went away')
+
+    monkeypatch.setattr(indexing, 'index', boom)
+    assert indexing.index_new_books() is None
+
+
+@pytest.mark.django_db
+def test_an_unreadable_book_is_counted_not_fatal(catalogue):
+    Book.objects.create(
+        filename='gone.fb2', path='.', filesize=1, format='fb2', cat_type=0,
+        docdate='2011', lang='en', title='Gone', search_title='GONE',
+        annotation='', avail=2, catalog=catalogue)
+    stats = indexing.index_new_books()
+
+    assert stats['unreadable'] == 1
+    # The name digests still land, so a rename-based match keeps working.
+    assert BookDigest.objects.filter(method=BookDigest.FILENAME).exists()
+
+
+@pytest.mark.django_db
+def test_the_digests_are_the_ones_the_matcher_looks_up(catalogue):
+    book = add_book(catalogue, FB2, 'Sparrow')
+    indexing.index_new_books()
+
+    from sopds_sync import linking
+    assert linking.resolve_book(filename_md5(FB2)) == book


### PR DESCRIPTION
The `BookDigest` index only ever covered the catalogue as it stood when someone last ran `sopds_kosync_index` by hand. Every book added after that was invisible to the matcher, so #71 quietly stopped applying to new books: progress from an e-reader kept syncing, it just no longer named a book — and nothing reported it.

A feature that degrades on its own between scans is worse than one that was never wired up.

## Changes

- Indexing moves out of the management command into `sopds_sync.indexing`; the command becomes a thin wrapper.
- The scanner runs it over the books it just added, alongside the counter refresh and the vacuum. Already idempotent — a book that has its digests costs one query — so a scan that added nothing costs nothing.
- Imported inside the function rather than at module scope, to keep the catalog app's import graph clear of the sync app.
- A no-op while `SOPDS_KOSYNC_ENABLE` is off, and it swallows its own errors: this runs after the scan has committed, and failing to index digests must not fail the scan that produced them.

## Tests

`sopds_sync/tests/test_index_on_scan.py`: new books indexed, a second run costing nothing, only the newly-added books touched, disabled-feature no-op, an indexing failure not propagating, an unreadable file counted rather than fatal, and the resulting digests being the ones `linking.resolve_book` actually looks up.