### PR TITLE
Cache the EPUB render and its illustrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,15 @@ All notable changes to this project are documented here. The format is based on
 - Tooling config in `pyproject.toml` (ruff, mypy); `CONTRIBUTING.md`.
 
 ### Changed
+- The EPUB reader no longer re-does its work on every request. Rendering a book
+  means unzipping it and parsing, sanitising and serialising every document in
+  its spine — a few hundred kilobytes of HTML — and the page then asked for each
+  illustration separately, **each of which re-read the entire archive** through
+  `getFileData`. A chapter with twenty pictures therefore read a 5 MB book
+  twenty-one times. The render and the images are now cached on the same content
+  validator the covers use, both routes answer `If-None-Match` with a 304, and a
+  book that *is* the archive is opened from disk instead of being slurped into
+  memory first, so only the members actually wanted get decompressed.
 - Covers and thumbnails answer conditional GETs. `/opds/cover/<id>/` and
   `/opds/thumb/<id>/` now send an `ETag` derived from the containing file's
   size and mtime — one `stat()`, no unzipping — so a reader revalidating with

--- a/opds_catalog/dl.py
+++ b/opds_catalog/dl.py
@@ -6,6 +6,7 @@ import hashlib
 import io
 import shlex
 import subprocess
+import contextlib
 import lxml.etree as ET
 import mimetypes
 import posixpath
@@ -46,6 +47,14 @@ Image.MAX_IMAGE_PIXELS = 64_000_000
 # plates are far below this; the cap stops a crafted archive from making the
 # reader page pull a multi-gigabyte member.
 MAX_RESOURCE_BYTES = 32 * 1024 * 1024
+
+# Illustrations at or below this go into the shared cache; anything larger is
+# streamed straight from the archive rather than evicting everything else.
+MAX_CACHED_RESOURCE_BYTES = 1024 * 1024
+
+# A rendered book is a few hundred kilobytes of HTML, which is worth caching;
+# an enormous one is not worth pushing everything else out of the cache for.
+MAX_CACHED_RENDER_BYTES = 4 * 1024 * 1024
 
 
 def require_catalog_access(view):
@@ -91,16 +100,21 @@ def container_path(book):
     return full_path
 
 
-def compute_cover_etag(book_id, thumbnail=False):
-    """Validator for the cover/thumbnail views, computed without opening the book.
+def compute_content_etag(book_id, variant):
+    """Validator for anything derived from a book file, without opening it.
 
-    Extracting a cover means unzipping and parsing the book, so the point of the
-    ETag is to answer a revalidation with 304 *before* any of that happens. The
-    validator therefore uses only what a single `stat()` gives us: the size and
-    mtime of the containing file, plus the entry that identifies the book inside
-    it. The scanner keys books on (filename, path) and never refreshes the row
-    when a file is replaced in place, so `Book.filesize` cannot be trusted here —
-    the on-disk mtime can.
+    Deriving a cover means unzipping and parsing the book; rendering an EPUB
+    means parsing every document in it. The point of the ETag is to answer a
+    revalidation with 304 *before* any of that happens, so the validator uses
+    only what a single `stat()` gives us: the size and mtime of the containing
+    file, plus the entry that identifies the book inside it. The scanner keys
+    books on (filename, path) and never refreshes the row when a file is
+    replaced in place, so `Book.filesize` cannot be trusted here — the on-disk
+    mtime can.
+
+    `variant` distinguishes the different things derived from the same file (a
+    cover, a thumbnail, the rendered text, one illustration) so they cannot
+    collide in a shared cache.
 
     Returns None (no ETag, no conditional handling, no caching) when the book or
     its file is gone; those paths end in a 404 or the no-cover placeholder.
@@ -111,30 +125,62 @@ def compute_cover_etag(book_id, thumbnail=False):
     except (Book.DoesNotExist, OSError):
         return None
 
-    key = '%s|%s|%s|%s|%s' % (
-        book_id, book.filename, st.st_size, st.st_mtime_ns,
-        settings.THUMB_SIZE if thumbnail else 'full',
-    )
+    key = '%s|%s|%s|%s|%s' % (book_id, book.filename, st.st_size,
+                              st.st_mtime_ns, variant)
     return '"%s"' % hashlib.sha256(key.encode('utf-8')).hexdigest()[:32]
 
 
-def cover_etag(request, book_id, thumbnail=False):
-    """`compute_cover_etag`, memoised for the duration of one request.
+def content_etag(request, book_id, variant):
+    """`compute_content_etag`, memoised for the duration of one request.
 
     The validator is needed twice per request — once by the `etag` decorator to
     answer conditional GETs, once by the view as its cache key — and each call
     costs a query plus a stat. Caching it on the request keeps that at one.
     """
-    memo = (book_id, bool(thumbnail))
-    if request is not None and getattr(request, '_cover_etag_for', None) == memo:
-        return request._cover_etag
+    memo = (book_id, variant)
+    if request is not None and getattr(request, '_content_etag_for', None) == memo:
+        return request._content_etag
 
-    value = compute_cover_etag(book_id, thumbnail)
+    value = compute_content_etag(book_id, variant)
     if request is not None:
-        request._cover_etag_for = memo
-        request._cover_etag = value
+        request._content_etag_for = memo
+        request._content_etag = value
 
     return value
+
+
+def cover_etag(request, book_id, thumbnail=False):
+    return content_etag(request, book_id,
+                        settings.THUMB_SIZE if thumbnail else 'full')
+
+
+def read_etag(request, book_id):
+    return content_etag(request, book_id, 'read')
+
+
+def resource_etag(request, book_id, path):
+    return content_etag(request, book_id, 'res:%s' % path)
+
+
+@contextlib.contextmanager
+def open_book_archive(book):
+    """A ZipFile over the book itself.
+
+    For a plain catalogue entry the book *is* the archive, so it is opened from
+    disk and only the members actually read get decompressed. Only a book stored
+    inside another zip has to be pulled into memory first — `getFileData` reads
+    the whole thing, which is why this is not used unconditionally.
+    """
+    if book.cat_type == opdsdb.CAT_NORMAL:
+        with zipfile.ZipFile(container_path(book)) as archive:
+            yield archive
+        return
+
+    data = getFileData(book)
+    if data is None:
+        raise Http404
+    with zipfile.ZipFile(data) as archive:
+        yield archive
 
 
 def nocover_response():
@@ -609,6 +655,7 @@ READABLE_FORMATS = ('fb2', 'epub')
 
 
 @require_catalog_access
+@etag(read_etag)
 def Read(request, book_id):
     """Dispatch to the renderer for this book's format."""
     book = get_object_or_404(Book, id=book_id)
@@ -618,28 +665,41 @@ def Read(request, book_id):
 
 
 def render_epub(request, book):
-    """ Чтение EPUB в браузере. Not a route: reached through `Read`. """
+    """ Чтение EPUB в браузере. Not a route: reached through `Read`.
+
+    Rendering means unzipping the book and parsing, sanitising and serialising
+    every document in its spine — a few hundred kilobytes of HTML out of dozens
+    of parses. Doing that per page view is what the cache is for; it is keyed on
+    the same content validator as the ETag, so replacing the file on disk
+    invalidates the render at once.
+    """
     if config.SOPDS_AUTH and request.user.is_authenticated:
         bookshelf.objects.get_or_create(user=request.user, book=book)
 
-    data = getFileData(book)
-    if data is None:
-        raise Http404
+    validator = read_etag(request, book.id)
+    cache_key = 'sopds-epub:%s' % validator.strip('"') if validator else None
 
-    def resource_url(path):
-        return reverse('opds_catalog:readres',
-                       kwargs={'book_id': book.id, 'path': path})
+    html = cache.get(cache_key) if cache_key else None
+    if html is None:
+        def resource_url(path):
+            return reverse('opds_catalog:readres',
+                           kwargs={'book_id': book.id, 'path': path})
+        try:
+            with open_book_archive(book) as archive:
+                html = epub_render.render_archive(archive, resource_url)
+        except (epub_render.EpubError, zipfile.BadZipFile, KeyError, OSError) as err:
+            logger.warning('Cannot render EPUB for book %s: %s', book.id, err)
+            raise Http404
+        if cache_key and len(html) <= MAX_CACHED_RENDER_BYTES:
+            cache.set(cache_key, html, config.SOPDS_CACHE_TIME)
 
-    try:
-        html = epub_render.render(data, resource_url)
-    except (epub_render.EpubError, zipfile.BadZipFile, KeyError) as err:
-        logger.warning('Cannot render EPUB for book %s: %s', book.id, err)
-        raise Http404
-
-    return HttpResponse(html, content_type='text/html; charset=utf-8')
+    response = HttpResponse(html, content_type='text/html; charset=utf-8')
+    patch_cache_control(response, private=True, max_age=config.SOPDS_CACHE_TIME)
+    return response
 
 
 @require_catalog_access
+@etag(resource_etag)
 def ReadResource(request, book_id, path):
     """Serve one image from inside an EPUB, for the rendered reader page.
 
@@ -652,24 +712,34 @@ def ReadResource(request, book_id, path):
     if book.format != 'epub':
         raise Http404
 
-    data = getFileData(book)
-    if data is None:
-        raise Http404
+    # normpath collapses any ".." before the lookup, and membership in the
+    # archive is the authorisation: a name that is not in it is a 404.
+    wanted = posixpath.normpath(path).lstrip('/')
 
-    try:
-        with zipfile.ZipFile(data) as archive:
-            # normpath collapses any ".." before the lookup, and membership in
-            # the archive is the authorisation: a name that is not in it is a 404.
-            wanted = posixpath.normpath(path).lstrip('/')
-            info = next((i for i in archive.infolist() if i.filename == wanted), None)
-            if info is None or info.file_size > MAX_RESOURCE_BYTES:
-                raise Http404
-            content_type = mimetypes.guess_type(wanted)[0] or ''
-            if not content_type.startswith('image/'):
-                raise Http404
-            payload = archive.read(info)
-    except zipfile.BadZipFile:
-        raise Http404
+    validator = resource_etag(request, book_id, wanted)
+    cache_key = 'sopds-epubres:%s' % validator.strip('"') if validator else None
+
+    cached = cache.get(cache_key) if cache_key else None
+    if cached is not None:
+        payload, content_type = cached
+    else:
+        content_type = mimetypes.guess_type(wanted)[0] or ''
+        if not content_type.startswith('image/'):
+            raise Http404
+        try:
+            with open_book_archive(book) as archive:
+                info = next((i for i in archive.infolist() if i.filename == wanted), None)
+                if info is None or info.file_size > MAX_RESOURCE_BYTES:
+                    raise Http404
+                payload = archive.read(info)
+        except (zipfile.BadZipFile, OSError):
+            raise Http404
+
+        # A page of illustrations is a burst of requests for the same archive,
+        # so caching the small ones turns the burst into one read. Large plates
+        # are served straight through rather than filling the cache with them.
+        if cache_key and len(payload) <= MAX_CACHED_RESOURCE_BYTES:
+            cache.set(cache_key, (payload, content_type), config.SOPDS_CACHE_TIME)
 
     response = HttpResponse(payload, content_type=content_type)
     patch_cache_control(response, private=True, max_age=config.SOPDS_CACHE_TIME)

--- a/opds_catalog/epub_render.py
+++ b/opds_catalog/epub_render.py
@@ -302,44 +302,53 @@ def number_paragraphs(body, index):
 
 
 def render(fileobj, resource_url):
-    """The whole book as one XHTML fragment.
+    """The whole book as one XHTML fragment, from a file-like object."""
+    with zipfile.ZipFile(fileobj) as archive:
+        return render_archive(archive, resource_url)
+
+
+def render_archive(archive, resource_url):
+    """The whole book as one XHTML fragment, from an open archive.
+
+    Taking the archive rather than a path lets a caller that already has one
+    open reuse it — the reader serves the text and every illustration out of the
+    same file, and reopening it per request is what made that expensive.
 
     `resource_url(archive_path) -> url` builds the URL for an image; it may
     return None to drop one.
     """
-    with zipfile.ZipFile(fileobj) as archive:
-        documents = spine_documents(archive)
-        names = set(archive.namelist())
-        parts = []
+    documents = spine_documents(archive)
+    names = set(archive.namelist())
+    parts = []
 
-        for index, path in enumerate(documents, start=1):
-            if path not in names:
-                logger.debug('EPUB spine references a missing document: %s', path)
-                continue
-            try:
-                document = _parse_xml(archive.read(path))
-            except (ET.XMLSyntaxError, ET.ParserError, ValueError) as err:
-                logger.debug('EPUB document %s did not parse: %s', path, err)
-                continue
+    for index, path in enumerate(documents, start=1):
+        if path not in names:
+            logger.debug('EPUB spine references a missing document: %s', path)
+            continue
+        try:
+            document = _parse_xml(archive.read(path))
+        except (ET.XMLSyntaxError, ET.ParserError, ValueError) as err:
+            logger.debug('EPUB document %s did not parse: %s', path, err)
+            continue
 
-            # Namespaces come off the whole document, not just the body: a
-            # declaration is only dropped once nothing under its owner uses it,
-            # and the xhtml default namespace is declared on <html>.
-            strip_namespaces(document)
-            body = next((e for e in document.iter()
-                         if _localname(e.tag) == 'body'), document)
+        # Namespaces come off the whole document, not just the body: a
+        # declaration is only dropped once nothing under its owner uses it,
+        # and the xhtml default namespace is declared on <html>.
+        strip_namespaces(document)
+        body = next((e for e in document.iter()
+                     if _localname(e.tag) == 'body'), document)
 
-            base = posixpath.dirname(path)
-            sanitize(body, lambda src, base=base: _image(src, base, names, resource_url))
-            number_paragraphs(body, index)
+        base = posixpath.dirname(path)
+        sanitize(body, lambda src, base=base: _image(src, base, names, resource_url))
+        number_paragraphs(body, index)
 
-            # The chapter marker the reader splits on, then the document itself
-            # flattened to a div so the fragment stays one flat stream.
-            parts.append('<a name="TOC_%d"></a>' % index)
-            body.tag = 'div'
-            for attribute in list(body.attrib):
-                del body.attrib[attribute]
-            parts.append(ET.tostring(body, encoding='unicode', method='html'))
+        # The chapter marker the reader splits on, then the document itself
+        # flattened to a div so the fragment stays one flat stream.
+        parts.append('<a name="TOC_%d"></a>' % index)
+        body.tag = 'div'
+        for attribute in list(body.attrib):
+            del body.attrib[attribute]
+        parts.append(ET.tostring(body, encoding='unicode', method='html'))
 
     if not parts:
         raise EpubError('nothing renderable in the archive')

--- a/opds_catalog/tests/test_epub_cache.py
+++ b/opds_catalog/tests/test_epub_cache.py
@@ -1,0 +1,148 @@
+"""Caching and conditional GETs for the EPUB reader.
+
+Rendering a book means unzipping it and parsing every document in its spine, and
+the page then asks for each illustration separately — each of which used to read
+the whole archive again.
+"""
+import os
+import shutil
+
+import pytest
+from django.core.cache import cache
+from django.urls import reverse
+from constance import config
+
+from opds_catalog import dl, epub_render
+from opds_catalog.models import Book, Catalog
+
+DATA = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
+EPUB = 'mirer.epub'
+IMAGE = 'OEBPS/images/MIRERUmenjadevjatzhiznejj.jpg'
+
+
+@pytest.fixture(autouse=True)
+def clean_cache():
+    cache.clear()
+    yield
+    cache.clear()
+
+
+@pytest.fixture
+def book(db, tmp_path, django_user_model, client):
+    # A private copy: the validator keys on mtime and one test rewrites it.
+    shutil.copy(os.path.join(DATA, EPUB), tmp_path / EPUB)
+    config.SOPDS_AUTH = True
+    config.SOPDS_ROOT_LIB = str(tmp_path)
+    cat = Catalog.objects.create(parent=None, cat_name='.', path='.', cat_type=0)
+    book = Book.objects.create(
+        filename=EPUB, path='.', filesize=os.path.getsize(tmp_path / EPUB),
+        format='epub', cat_type=0, docdate='2011', lang='ru', title='Mirer',
+        search_title='MIRER', annotation='', avail=2, catalog=cat)
+    client.force_login(django_user_model.objects.create_user(username='r', password='pw'))
+    return book
+
+
+def res_url(book, path=IMAGE):
+    return reverse('opds:readres', kwargs={'book_id': book.id, 'path': path})
+
+
+# --- the rendered text -----------------------------------------------------
+
+@pytest.mark.django_db
+def test_the_render_is_cached(client, book, monkeypatch):
+    url = reverse('opds:read', args=[book.id])
+    first = client.get(url)
+    assert first.status_code == 200
+
+    def fail(*args, **kwargs):
+        raise AssertionError('the book was parsed again on a cache hit')
+
+    monkeypatch.setattr(epub_render, 'render_archive', fail)
+    second = client.get(url)
+    assert second.status_code == 200
+    assert second.content == first.content
+
+
+@pytest.mark.django_db
+def test_revalidation_returns_304(client, book):
+    url = reverse('opds:read', args=[book.id])
+    etag = client.get(url)['ETag']
+
+    resp = client.get(url, headers={'if-none-match': etag})
+    assert resp.status_code == 304
+    assert resp.content == b''
+
+
+@pytest.mark.django_db
+def test_replacing_the_file_invalidates_the_render(client, book, tmp_path):
+    url = reverse('opds:read', args=[book.id])
+    before = client.get(url)
+    assert before.status_code == 200
+
+    (tmp_path / EPUB).write_bytes(b'not a book any more')
+    assert client.get(url).status_code == 404
+
+
+@pytest.mark.django_db
+def test_the_reader_page_is_privately_cacheable(client, book):
+    """It is behind authentication, so no shared proxy may keep it."""
+    resp = client.get(reverse('opds:read', args=[book.id]))
+    assert 'private' in resp['Cache-Control']
+
+
+# --- illustrations ---------------------------------------------------------
+
+@pytest.mark.django_db
+def test_an_image_is_cached(client, book, monkeypatch):
+    assert client.get(res_url(book)).status_code == 200
+
+    def fail(*args, **kwargs):
+        raise AssertionError('the archive was reopened on a cache hit')
+
+    monkeypatch.setattr(dl, 'open_book_archive', fail)
+    resp = client.get(res_url(book))
+    assert resp.status_code == 200
+    assert resp['Content-Type'] == 'image/jpeg'
+
+
+@pytest.mark.django_db
+def test_an_image_revalidates_to_304(client, book):
+    etag = client.get(res_url(book))['ETag']
+    resp = client.get(res_url(book), headers={'if-none-match': etag})
+    assert resp.status_code == 304
+
+
+@pytest.mark.django_db
+def test_text_and_image_do_not_share_a_cache_entry(client, book):
+    text = client.get(reverse('opds:read', args=[book.id]))
+    image = client.get(res_url(book))
+    assert text['ETag'] != image['ETag']
+    assert image['Content-Type'] == 'image/jpeg'
+
+
+@pytest.mark.django_db
+def test_two_images_do_not_share_a_cache_entry(client, book):
+    """The validator has to include the member path, not just the book."""
+    one = dl.resource_etag(None, book.id, IMAGE)
+    two = dl.resource_etag(None, book.id, 'OEBPS/images/other.jpg')
+    assert one != two
+
+
+@pytest.mark.django_db
+def test_a_refused_path_is_still_refused_when_cached(client, book):
+    """Rejection happens before the cache, so a 404 cannot be poisoned into a 200."""
+    for _ in range(2):
+        assert client.get(res_url(book, 'OEBPS/content.opf')).status_code == 404
+        assert client.get(res_url(book, '../../../etc/passwd')).status_code == 404
+
+
+@pytest.mark.django_db
+def test_a_plain_epub_is_read_without_slurping_the_whole_file(book, monkeypatch):
+    """`getFileData` reads the entire book into memory; for a book that *is* the
+    archive there is no reason to."""
+    def fail(*args, **kwargs):
+        raise AssertionError('the whole archive was read into memory')
+
+    monkeypatch.setattr(dl, 'getFileData', fail)
+    with dl.open_book_archive(book) as archive:
+        assert IMAGE in archive.namelist()


### PR DESCRIPTION
Follow-up to #75, fixing two things it shipped with.

Serving a rendered EPUB meant unzipping the book and parsing, sanitising and serialising **every document in its spine, on every request** — 425 KB of HTML out of thirty parses for the sample book, with nothing kept.

The illustrations were worse. Each one called `getFileData`, which reads the **whole book into memory** before the member is even located, so a chapter with twenty pictures read a 5 MB archive twenty-one times to serve it once.

## Changes

- Render and images are cached on the content validator the covers already use, extended with a `variant` so a cover, a thumbnail, the text and each individual image cannot collide in the shared cache.
- Both routes carry an `ETag`, so a reader revalidating gets a bodyless **304** instead of the whole render again.
- `open_book_archive()` opens a plain EPUB straight from disk, letting `zipfile` seek to the member rather than holding the entire book in memory. Only a book stored *inside* another zip still has to be extracted first.
- Both caches have a size cap: a page of small plates is exactly the burst worth absorbing, a single enormous one is not worth evicting everything else for and is served straight through.

## Measured

On the sample book (`mirer.epub`, 30 spine documents):

| | |
|---|---|
| cold render | 17.4 ms, 425 KB |
| cached | 3.6 ms |
| revalidated (304) | 1.2 ms, 0 bytes |

## Tests

`opds_catalog/tests/test_epub_cache.py`: the render cached and not re-parsed, 304 on revalidation, invalidation when the file is replaced, images cached without reopening the archive, text/image and image/image cache keys kept distinct, a refused path staying refused across requests (rejection happens before the cache, so a 404 cannot be poisoned into a 200), and a plain EPUB being read without slurping the whole file.