### PR TITLE
Release 0.50.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+## [0.50.0] - 2026-07-26
+
+First release of the Lectern fork. Everything below has accumulated since
+**v0.49** (September 2022): the rebrand and UI rewrite, the move to Django 5.2,
+a long run of scanner and parser hardening, several security fixes, and the
+reading, sync and metadata features added on top.
+
+Versions are three-part from here on. The `v0.50` tag in this repository
+belongs to the unrelated `sarutobi/sopds-ng` fork, which is why our own
+sequence continues at `v0.50.0` rather than reusing that name.
+
+### Upgrading
+
+Run `python manage.py migrate` — this release adds migrations `0011`–`0023`
+in `opds_catalog`, and the whole of the new `sopds_sync` app (`0001`, `0002`).
+Two of them (`0016`, `0020`) build indexes over `opds_catalog_book` and hold a
+write lock on it for the duration, so pick a scan-free window on a large
+catalogue.
+
+Optional, once migrated:
+
+- `python manage.py sopds_isbn_backfill` — fill `isbn` for books already in
+  the catalogue (a normal incremental scan skips them).
+- `python manage.py sopds_enrich` — fill empty annotations, dates and
+  publishers from Open Library, for books that have an ISBN.
+- `python manage.py sopds_kosync_index` — build the KOReader digest index for
+  the existing catalogue. Only needed once; scans keep it current afterwards.
+
 ### Added
 - **Download and read statistics, and a "Most popular" listing.** Nothing
   recorded what the library was actually used for, so the one entry point still

--- a/opds_catalog/settings.py
+++ b/opds_catalog/settings.py
@@ -4,7 +4,7 @@ from django.conf import settings
 loglevels={'debug':logging.DEBUG,'info':logging.INFO,'warning':logging.WARNING,'error':logging.ERROR,'critical':logging.CRITICAL,'none':logging.NOTSET}
 NOZIP_FORMATS = ['epub', 'mobi']
 
-VERSION = "0.49"
+VERSION = "0.50.0"
 TITLE = getattr(settings, "SOPDS_TITLE", "Lectern")
 SUBTITLE = getattr(settings, "SOPDS_SUBTITLE", "Lectern — OPDS catalog. Version %s."%VERSION)
 ICON = getattr(settings, "SOPDS_ICON", "/static/images/favicon.ico")


### PR DESCRIPTION
Closes out everything accumulated since **v0.49 (September 2022)**: the Lectern rebrand and UI rewrite, Django 5.2, a long run of scanner and parser hardening, several security fixes, and the reading, sync and metadata work on top.

## On the version number

Our lineage ran v0.47 → v0.48 → v0.48f → v0.49. The plain `v0.50` tag present in this clone belongs to the unrelated **`sarutobi/sopds-ng`** fork — it is not an ancestor of our `master` (different tree: `version.txt`, docker, travis) and it is not on `duckhawk/sopds`. Versions become three-part here, so the sequence continues at **v0.50.0** rather than colliding with a name already taken.

`VERSION` in `opds_catalog/settings.py` had been left at `"0.49"` throughout and now says what it is.

## Changes

- `VERSION = "0.50.0"`.
- `CHANGELOG.md`: `[Unreleased]` becomes `[0.50.0] - 2026-07-26`, with a fresh empty `[Unreleased]` above it.
- An **Upgrading** section: which migrations run (`0011`–`0023` in `opds_catalog`, plus the whole new `sopds_sync` app), a warning that `0016` and `0020` hold a write lock on `opds_catalog_book` while they build indexes, and the three optional one-off backfill commands (`sopds_isbn_backfill`, `sopds_enrich`, `sopds_kosync_index`).

430 tests pass, ruff clean, `makemigrations --check` clean. The tag is cut after this merges.