### PR TITLE
Follow the rename to Lectern in docs, User-Agent and the OPDS descriptor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,5 +47,5 @@ Keep it clean.
 ## Deployment
 
 Production is deployed from the separate `sopds-k8s` repository (werf + GitLab
-CI). That repo pins a specific `duckhawk/sopds` commit; after merging to
+CI). That repo pins a specific `duckhawk/lectern` commit; after merging to
 `master`, bump the pin there.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-#### SimpleOPDS Catalog
-#### Author: Dmitry V.Shelepnev
-#### Version 0.47-devel
+#### Lectern — OPDS catalog
+#### A fork of Simple OPDS (SOPDS) by Dmitry V. Shelepnev
+#### See CHANGELOG.md for the current version and what has changed
 
 [Инструкция на русском языке: README_RUS.md](README_RUS.md)
 
@@ -10,7 +10,7 @@
 You can download the archive with the project from www.sopds.ru,
 or from github.com with the following command:
 
-	git clone https://github.com/mitshel/sopds.git
+	git clone https://github.com/duckhawk/lectern.git
 
 1.2 Dependencies.
 - Requires Python at least version 3.4

--- a/README_RUS.md
+++ b/README_RUS.md
@@ -1,6 +1,6 @@
-#### SimpleOPDS Catalog - Простой OPDS Каталог
-#### Author: Dmitry V.Shelepnev  
-#### Версия 0.47-devel
+#### Lectern — OPDS-каталог
+#### Форк Simple OPDS (SOPDS), автор оригинала — Dmitry V. Shelepnev
+#### Текущая версия и список изменений — в CHANGELOG.md
 
 [English README.md](README.md)
 
@@ -10,7 +10,7 @@
 Загрузить архив с проектом можно с сайта www.sopds.ru, 
 либо из github.com следующей командой:
 
-	git clone https://github.com/mitshel/sopds.git
+	git clone https://github.com/duckhawk/lectern.git
 
 1.2 Зависимости.  
 - Требуется Python не ниже версии 3.4

--- a/opds_catalog/feeds.py
+++ b/opds_catalog/feeds.py
@@ -349,7 +349,8 @@ def OpenSearch(request):
     """
     Выводим шаблон поиска
     """
-    return render(request, 'opensearch.html')
+    return render(request, 'opensearch.html',
+                  {'title': settings.TITLE, 'icon': settings.ICON})
 
 class SearchTypesFeed(AuthFeed):
     feed_type = opdsFeed

--- a/opds_catalog/openlibrary.py
+++ b/opds_catalog/openlibrary.py
@@ -14,7 +14,7 @@ API_URL = 'https://openlibrary.org/api/books'
 
 # Open Library asks callers to identify themselves so they can contact the
 # operator of a misbehaving client instead of blocking it outright.
-USER_AGENT = 'Lectern-OPDS/1.0 (+https://github.com/mitshel/sopds) metadata enrichment'
+USER_AGENT = 'Lectern-OPDS/1.0 (+https://github.com/duckhawk/lectern) metadata enrichment'
 
 # The API takes many bibkeys per call. Keep the batch well under the point where
 # the query string gets unwieldy; 50 ISBNs is ~750 characters.

--- a/opds_catalog/templates/opensearch.html
+++ b/opds_catalog/templates/opensearch.html
@@ -1,10 +1,17 @@
 {% autoescape off %}
 <?xml version="1.0" encoding="utf-8"?>
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
-    <ShortName>SimpleOPDS</ShortName>
-    <LongName>SimpleOPDS</LongName>
+    <ShortName>{{ title }}</ShortName>
+    <LongName>{{ title }}</LongName>
     <Url type="application/atom+xml" template="{% url "opds_catalog:opensearch" %}{searchTerms}/" />
-    <Image width="16" height="16">http://www.sopds.ru/favicon.ico</Image>
+    {% comment %}
+    Our own icon. This used to point at http://www.sopds.ru/favicon.ico, so every
+    reader that read the descriptor fetched an image from a third-party site over
+    plain HTTP — and showed nothing once that site was unreachable. Note the
+    {% templatetag opencomment %}..{% templatetag closecomment %} form is
+    single-line only; spanning lines with it emits the text verbatim.
+    {% endcomment %}
+    <Image width="16" height="16">{{ icon }}</Image>
     <Tags />
     <Contact />
     <Developer />

--- a/opds_catalog/tests/test_feeds.py
+++ b/opds_catalog/tests/test_feeds.py
@@ -4,7 +4,7 @@ from django.urls import reverse
 from django.test import TestCase, Client
 from django.utils.translation import gettext as _
 
-from opds_catalog import opdsdb
+from opds_catalog import opdsdb, settings
 from constance import config
 
 
@@ -48,7 +48,12 @@ class feedsTestCase(TestCase):
         c = Client()
         response = c.get('/opds/search/')
         self.assertEqual(response.status_code, 200)
-        self.assertIn('www.sopds.ru', response.content.decode())
+        body = response.content.decode()
+        # The descriptor names this catalog and points at an icon we serve.
+        # It used to advertise SimpleOPDS and http://www.sopds.ru/favicon.ico.
+        self.assertIn(settings.TITLE, body)
+        self.assertIn(settings.ICON, body)
+        self.assertNotIn('sopds.ru', body)
         
     def test_SearchTypes(self):
         c = Client()


### PR DESCRIPTION
The repository is now `duckhawk/lectern`. Several places still pointed at the upstream project this was forked from seven years ago.

## What was pointing at upstream

- **Both READMEs told you to clone `https://github.com/mitshel/sopds.git`** — that hands you the 2019 upstream, not this project. Their headers also still announced *"SimpleOPDS Catalog, Version 0.47-devel"*.
- **The Open Library User-Agent** pointed at the upstream repository, so the one contact address we give a third-party service for our traffic named someone with nothing to do with it. That one was mine, from #70.
- **The OpenSearch descriptor** advertised the catalog as "SimpleOPDS" and pointed its icon at `http://www.sopds.ru/favicon.ico`. Every reader that fetched the descriptor then fetched an image from a third-party host over plain HTTP — and got nothing at all once that host was unreachable. It now names this catalog and uses the icon we already serve.
- `CONTRIBUTING.md` referred to the old repo name.

## A bug the test caught

The descriptor test asserted the *presence* of the third-party URL; it now asserts the opposite. That immediately caught a Django template comment I had written across three lines — `{# #}` is **single-line only**, so the multi-line form was being emitted verbatim into the XML every OPDS client reads. Switched to `{% comment %}`.

## Elsewhere

`sopds-k8s` had two hardcoded clone URLs; updated and pushed separately. **Its commit pin was deliberately left alone** — it still points at `b6513ac`, which predates fifteen merged PRs including migrations that hold a write lock on `opds_catalog_book` while building indexes. Bumping it is a deployment needing a scan-free window, not a side effect of a rename.

430 tests pass, ruff clean.