### PR TITLE
Give books their authors during Open Library enrichment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to this project are documented here. The format is based on
 ## [Unreleased]
 
 ### Added
+- `sopds_enrich` now also gives a book its **authors**, when it has none and
+  Open Library knows them. A book whose file carried no author metadata was
+  previously unreachable through the author browser and the author search;
+  now it is. An author that is already recorded is never replaced, not even
+  under `--force` — the parser read that name out of the file itself, one ISBN
+  can cover editions credited differently, and overwriting a known author with
+  a remote guess is very hard to undo once it has run over a whole catalogue.
+  Author rows are reused rather than duplicated, get their search name filled
+  so the new author is findable, and are capped per book.
+  Cover images are still not fetched: that needs either a third-party request
+  from every reader's browser — which the OPDS descriptor was just cured of —
+  or local storage this project does not yet have, so it wants its own change.
 - **Genres can be searched by name**, in OPDS (`/opds/search/genres/m/<term>/`,
   and an entry in the OPDS search menu) and in the web UI (a *Genre* option in
   the search-type chooser). They were browsable through the section tree but

--- a/opds_catalog/management/commands/sopds_enrich.py
+++ b/opds_catalog/management/commands/sopds_enrich.py
@@ -22,13 +22,16 @@ from django.db import close_old_connections
 from django.db.models import Q
 from django.utils import timezone
 
-from opds_catalog import openlibrary
+from opds_catalog import openlibrary, opdsdb
 from opds_catalog.models import (
     Book, SIZE_BOOK_ANNOTATION, SIZE_BOOK_DOCDATE, SIZE_BOOK_PUBLISHER,
 )
 
 # Field -> column width, so a long remote value is truncated rather than
 # rejected by the DB.
+# A sane ceiling on how many authors one remote record may attach.
+MAX_AUTHORS = 10
+
 FIELD_LIMITS = {
     'annotation': SIZE_BOOK_ANNOTATION,
     'docdate': SIZE_BOOK_DOCDATE,
@@ -70,7 +73,7 @@ class Command(BaseCommand):
             books = books[:limit]
         books = list(books)
 
-        looked_up = updated = not_found = nothing_new = failed = 0
+        looked_up = updated = not_found = nothing_new = failed = authors_added = 0
         # Only books whose batch actually reached the API get stamped as tried; a
         # batch lost to a timeout has to stay a candidate for the next run.
         answered = []
@@ -101,14 +104,18 @@ class Command(BaseCommand):
 
                 for book in rows:
                     changed = self.apply(book, fields, force)
-                    if not changed:
+                    got_authors = self.apply_authors(book, fields.get('authors'), dry_run)
+                    if not changed and not got_authors:
                         nothing_new += 1
                         continue
 
                     updated += 1
+                    if got_authors:
+                        authors_added += 1
                     if verbose:
+                        named = sorted(changed) + (['authors'] if got_authors else [])
                         self.stdout.write('Book %s (%s): %s'
-                                          % (book.id, book.isbn, ', '.join(sorted(changed))))
+                                          % (book.id, book.isbn, ', '.join(named)))
                     if not dry_run:
                         changed['enriched'] = timezone.now()
                         Book.objects.filter(pk=book.pk).update(**changed)
@@ -121,10 +128,11 @@ class Command(BaseCommand):
         prefix = 'DRY-RUN: ' if dry_run else ''
         self.stdout.write(
             '%sEnrichment done. Candidates: %d, ISBNs looked up: %d, %s: %d, '
-            'not in Open Library: %d, nothing to add: %d, lookups failed: %d'
+            'not in Open Library: %d, nothing to add: %d, lookups failed: %d, '
+            'given authors: %d'
             % (prefix, len(books), looked_up,
                'would update' if dry_run else 'updated', updated, not_found,
-               nothing_new, failed)
+               nothing_new, failed, authors_added)
         )
 
     def candidates(self, force):
@@ -134,14 +142,15 @@ class Command(BaseCommand):
             return qs.order_by('id')
         # Skip anything a previous run already resolved or tried, and anything
         # that has nothing left to fill.
-        has_a_gap = Q(annotation='') | Q(docdate='') | Q(publisher='')
+        has_a_gap = (Q(annotation='') | Q(docdate='') | Q(publisher='')
+                     | Q(authors__isnull=True))
         return qs.filter(enriched__isnull=True).filter(has_a_gap).order_by('id')
 
     def apply(self, book, fields, force):
         """Return the subset of `fields` this book should actually be updated with."""
         changed = {}
         for name, value in fields.items():
-            if not value:
+            if not value or name not in FIELD_LIMITS:
                 continue
             if not force and getattr(book, name):
                 continue
@@ -149,6 +158,24 @@ class Command(BaseCommand):
             if new != getattr(book, name):
                 changed[name] = new
         return changed
+
+    def apply_authors(self, book, names, dry_run):
+        """Attach authors to a book that has none. Returns True if it did.
+
+        Only ever fills a gap: a book that already has an author keeps it, even
+        under --force. The parser read that name out of the file itself, and one
+        ISBN can cover editions credited differently — a translation, an
+        anthology, an edition that adds an illustrator. Replacing a known author
+        with a remote guess is the kind of "fix" that is very hard to undo once
+        it has run over a whole catalogue.
+        """
+        if not names or book.authors.exists():
+            return False
+
+        if not dry_run:
+            for name in names[:MAX_AUTHORS]:
+                opdsdb.addbauthor(book, opdsdb.addauthor(name))
+        return True
 
     def mark_tried(self, books):
         ids = [b.pk for b in books]

--- a/opds_catalog/openlibrary.py
+++ b/opds_catalog/openlibrary.py
@@ -51,6 +51,17 @@ def parse_details(details):
     if isinstance(publish_date, str) and publish_date.strip():
         out['docdate'] = publish_date.strip()
 
+    # Open Library gives authors as [{'name': ..., 'key': ...}]. Only the names
+    # are useful here: the catalogue keys authors by name, and matching an
+    # Open Library author key to a local Author would be guesswork.
+    names = []
+    for author in details.get('authors') or []:
+        name = (author or {}).get('name') if isinstance(author, dict) else None
+        if isinstance(name, str) and name.strip():
+            names.append(name.strip())
+    if names:
+        out['authors'] = names
+
     return out
 
 

--- a/opds_catalog/tests/test_enrich.py
+++ b/opds_catalog/tests/test_enrich.py
@@ -11,7 +11,8 @@ from django.core.management import call_command
 from django.utils import timezone
 
 from opds_catalog import openlibrary
-from opds_catalog.models import Book, Catalog
+from opds_catalog import opdsdb
+from opds_catalog.models import Author, Book, Catalog
 
 ISBN = '9780306406157'
 OTHER = '9783161484100'
@@ -289,3 +290,110 @@ def test_a_book_already_enriched_by_hand_is_left_alone(catalogue, fake_api):
 
     call_command('sopds_enrich', '--sleep', '0')
     assert fake_api['asked'] == []
+
+
+# --- authors ---------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_a_book_with_no_author_gets_one(catalogue, fake_api):
+    book = catalogue('Anonymous book', isbn=ISBN)
+    fake_api['answer'] = {ISBN: {'authors': ['Ellis Peters']}}
+
+    call_command('sopds_enrich', '--sleep', '0')
+
+    assert [a.full_name for a in book.authors.all()] == ['Ellis Peters']
+
+
+@pytest.mark.django_db
+def test_several_authors_are_all_attached(catalogue, fake_api):
+    book = catalogue('Collaboration', isbn=ISBN)
+    fake_api['answer'] = {ISBN: {'authors': ['Arkady Strugatsky', 'Boris Strugatsky']}}
+
+    call_command('sopds_enrich', '--sleep', '0')
+
+    assert sorted(a.full_name for a in book.authors.all()) == \
+        ['Arkady Strugatsky', 'Boris Strugatsky']
+
+
+@pytest.mark.django_db
+def test_an_existing_author_is_never_replaced(catalogue, fake_api):
+    """The parser read that name out of the file, and one ISBN can cover
+    editions credited differently. Not even --force overrides it."""
+    book = catalogue('Credited book', isbn=ISBN)
+    book.authors.add(opdsdb.addauthor('Real Author'))
+    fake_api['answer'] = {ISBN: {'authors': ['Someone Else']}}
+
+    call_command('sopds_enrich', '--force', '--sleep', '0')
+
+    assert [a.full_name for a in book.authors.all()] == ['Real Author']
+
+
+@pytest.mark.django_db
+def test_an_author_row_is_reused_not_duplicated(catalogue, fake_api):
+    first = catalogue('One', isbn=ISBN)
+    second = catalogue('Two', isbn=OTHER)
+    fake_api['answer'] = {ISBN: {'authors': ['Ellis Peters']},
+                          OTHER: {'authors': ['Ellis Peters']}}
+
+    call_command('sopds_enrich', '--sleep', '0')
+
+    assert Author.objects.filter(full_name='Ellis Peters').count() == 1
+    assert first.authors.first() == second.authors.first()
+
+
+@pytest.mark.django_db
+def test_the_author_gets_its_search_name_filled(catalogue, fake_api):
+    """Otherwise the new author is invisible to the author search."""
+    catalogue('Anonymous book', isbn=ISBN)
+    fake_api['answer'] = {ISBN: {'authors': ['Ellis Peters']}}
+
+    call_command('sopds_enrich', '--sleep', '0')
+
+    author = Author.objects.get(full_name='Ellis Peters')
+    assert author.search_full_name == 'ELLIS PETERS'
+
+
+@pytest.mark.django_db
+def test_a_book_needing_only_authors_is_still_a_candidate(catalogue, fake_api):
+    """It has every scalar field filled, so the old query skipped it."""
+    catalogue('Complete but anonymous', isbn=ISBN,
+              annotation='a', docdate='1982', publisher='Gollancz')
+    fake_api['answer'] = {ISBN: {'authors': ['Ellis Peters']}}
+
+    call_command('sopds_enrich', '--sleep', '0')
+
+    assert fake_api['asked'] == [ISBN]
+    assert Author.objects.filter(full_name='Ellis Peters').exists()
+
+
+@pytest.mark.django_db
+def test_dry_run_attaches_nobody(catalogue, fake_api):
+    book = catalogue('Anonymous book', isbn=ISBN)
+    fake_api['answer'] = {ISBN: {'authors': ['Ellis Peters']}}
+
+    call_command('sopds_enrich', '--dry-run', '--sleep', '0')
+
+    assert not book.authors.exists()
+    assert not Author.objects.exists()
+
+
+@pytest.mark.django_db
+def test_an_absurd_author_list_is_capped(catalogue, fake_api):
+    book = catalogue('Anthology', isbn=ISBN)
+    fake_api['answer'] = {ISBN: {'authors': ['Author %d' % n for n in range(50)]}}
+
+    call_command('sopds_enrich', '--sleep', '0')
+
+    assert book.authors.count() == 10
+
+
+def test_parse_details_reads_author_names():
+    fields = openlibrary.parse_details(
+        {'authors': [{'name': 'Ellis Peters', 'key': '/authors/OL1A'}]})
+    assert fields['authors'] == ['Ellis Peters']
+
+
+def test_parse_details_ignores_malformed_author_entries():
+    fields = openlibrary.parse_details(
+        {'authors': [{'key': '/authors/OL1A'}, None, 'plain string', {'name': '  '}]})
+    assert 'authors' not in fields


### PR DESCRIPTION
A book whose file carried no author metadata was unreachable through the author browser and the author search — it existed only under its title. Where such a book has an ISBN, Open Library usually knows who wrote it.

## The rule: fill, never replace

Authors are only added to a book that has **none**, and that holds under `--force` too — unlike the scalar fields, which `--force` does overwrite.

The parser read the existing name out of the file itself; one ISBN can cover editions credited differently (a translation, an anthology, an edition that adds an illustrator); and replacing a known author with a remote guess is the kind of correction that is very hard to undo after it has run over a whole catalogue. Filling a gap is safe, overwriting is not.

## Details

- Attaching goes through `opdsdb.addauthor`, the same path the scanner uses, so an author row is **reused rather than duplicated** and gets its `search_full_name` filled — without which the new author would be invisible to the author search.
- The number of authors one remote record may attach is capped.
- Books that need *only* authors are now candidates: the previous query looked only for empty scalar fields and skipped a book that had all of those but no author.

## Not included: cover images

They would need either a third-party request from every reader's browser — which the OPDS descriptor was just cured of in #80 — or local storage this project does not have. That decision deserves its own change rather than being smuggled in here.

## Tests

10 new tests in `test_enrich.py`: a book gaining an author, several authors, an existing author surviving `--force`, author rows reused not duplicated, the search name filled, an authors-only book being a candidate, dry-run attaching nobody, the cap, and the parser ignoring malformed author entries.

460 tests pass, ruff clean.