### PR TITLE
Expose Prometheus metrics for the catalogue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to this project are documented here. The format is based on
 ## [Unreleased]
 
 ### Added
+- **Prometheus metrics at `/metrics`**, off by default
+  (`SOPDS_METRICS_ENABLE`), with an optional bearer token
+  (`SOPDS_METRICS_TOKEN`). Until now the only observability was a liveness and
+  a readiness probe, so a deployment could not answer how big the catalogue
+  is, how much is being taken out of it, or — the failure this catalogue
+  actually has — whether the scan is still running at all.
+  Everything exposed is derived from the database on scrape rather than
+  accumulated in the process: the app runs several uwsgi workers, so an
+  in-process counter would describe only whichever worker answered, and
+  getting that right means `prometheus_client`'s multiprocess mode with its
+  shared directory and per-worker cleanup. Gauges read from the DB are the
+  same number whoever answers. Per-request latency and rate are genuinely
+  per-process and are left to an ingress or sidecar that sees every request.
+  `lectern_last_scan_timestamp_seconds` is absent rather than zero when no
+  scan has ever finished, so an alert on staleness can tell the two apart.
+  The body is cached briefly, because several of the gauges are `COUNT()`s
+  over the whole book table and scrapes are frequent.
 - `sopds_enrich` now also gives a book its **authors**, when it has none and
   Open Library knows them. A book whose file carried no author metadata was
   previously unreachable through the author browser and the author search;

--- a/opds_catalog/tests/test_constance.py
+++ b/opds_catalog/tests/test_constance.py
@@ -14,10 +14,12 @@ class constanceTestCase(TestCase):
         pass
 
     def test_constance_attributes_count(self):
+        # A tripwire against losing a setting by accident: bump it deliberately
+        # when adding one. 47 before SOPDS_METRICS_ENABLE / SOPDS_METRICS_TOKEN.
         out = StringIO()
         call_command('constance', 'list', stdout=out)
         out.seek(0)
-        self.assertEqual(out.getvalue().count('\n'), 47)
+        self.assertEqual(out.getvalue().count('\n'), 49)
         out.close()
 
     def test_constance_set_get_attr(self):

--- a/opds_catalog/tests/test_metrics.py
+++ b/opds_catalog/tests/test_metrics.py
@@ -1,0 +1,190 @@
+"""The Prometheus scrape endpoint."""
+import pytest
+from django.core.cache import cache
+from django.utils import timezone
+from constance import config
+
+from opds_catalog import stats
+from opds_catalog.models import Book, BookStat, Catalog, Counter, bookshelf
+from sopds import metrics
+
+
+@pytest.fixture(autouse=True)
+def enabled(db):
+    config.SOPDS_METRICS_ENABLE = True
+    config.SOPDS_METRICS_TOKEN = ''
+    cache.delete(metrics.CACHE_KEY)
+    yield
+    cache.delete(metrics.CACHE_KEY)
+
+
+@pytest.fixture
+def catalogue(db, django_user_model):
+    cat = Catalog.objects.create(parent=None, cat_name='.', path='.', cat_type=0)
+    books = []
+    for n, isbn in enumerate(['9780306406157', '']):
+        books.append(Book.objects.create(
+            filename='b%d.fb2' % n, path='.', filesize=1, format='fb2', cat_type=0,
+            docdate='2011', lang='en', title='B%d' % n, search_title='B%d' % n,
+            annotation='', avail=2, catalog=cat, isbn=isbn))
+    user = django_user_model.objects.create_user(username='r', password='pw')
+    bookshelf.objects.create(user=user, book=books[0], rating=4)
+    Counter.objects.update_known_counters()
+    return books
+
+
+def scrape(client, **extra):
+    return client.get('/metrics', **extra)
+
+
+def values(body):
+    """{metric name (with labels stripped): value} from an exposition body."""
+    out = {}
+    for line in body.splitlines():
+        if not line or line.startswith('#'):
+            continue
+        name, _, value = line.rpartition(' ')
+        out[name.split('{')[0]] = value
+    return out
+
+
+# --- shape -----------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_exposes_the_prometheus_content_type(client, catalogue):
+    resp = scrape(client)
+    assert resp.status_code == 200
+    assert resp['Content-Type'].startswith('text/plain')
+    assert 'version=0.0.4' in resp['Content-Type']
+
+
+@pytest.mark.django_db
+def test_every_metric_has_help_and_type(client, catalogue):
+    body = scrape(client).content.decode()
+    named = {ln.split()[2] for ln in body.splitlines() if ln.startswith('# HELP')}
+    typed = {ln.split()[2] for ln in body.splitlines() if ln.startswith('# TYPE')}
+    assert named and named == typed
+
+    for name in values(body):
+        assert name in named, '%s has no HELP line' % name
+
+
+@pytest.mark.django_db
+def test_counts_come_from_the_catalogue(client, catalogue):
+    got = values(scrape(client).content.decode())
+    assert got['lectern_books_total'] == '2'
+    assert got['lectern_books_with_isbn_total'] == '1'
+    assert got['lectern_books_rated_total'] == '1'
+    assert got['lectern_database_up'] == '1'
+
+
+@pytest.mark.django_db
+def test_build_info_carries_the_version(client, catalogue):
+    from opds_catalog import settings as catalog_settings
+    body = scrape(client).content.decode()
+    assert 'lectern_build_info{version="%s"} 1' % catalog_settings.VERSION in body
+
+
+@pytest.mark.django_db
+def test_download_and_read_totals(client, catalogue):
+    stats.record(catalogue[0].id, stats.DOWNLOADS)
+    stats.record(catalogue[0].id, stats.DOWNLOADS)
+    stats.record(catalogue[1].id, stats.READS)
+    cache.delete(metrics.CACHE_KEY)
+
+    got = values(scrape(client).content.decode())
+    assert got['lectern_downloads_total'] == '2'
+    assert got['lectern_reads_total'] == '1'
+
+
+@pytest.mark.django_db
+def test_totals_are_zero_not_missing_when_nothing_was_taken(client, catalogue):
+    assert BookStat.objects.count() == 0
+    got = values(scrape(client).content.decode())
+    assert got['lectern_downloads_total'] == '0'
+
+
+# --- the metric worth alerting on ------------------------------------------
+
+@pytest.mark.django_db
+def test_last_scan_is_reported_as_a_unix_timestamp(client, catalogue):
+    got = values(scrape(client).content.decode())
+    when = int(got['lectern_last_scan_timestamp_seconds'])
+    assert abs(when - int(timezone.now().timestamp())) < 300
+
+
+@pytest.mark.django_db
+def test_last_scan_is_absent_rather_than_zero_when_none_has_run(client, db):
+    """"Never scanned" is not "scanned at the epoch" — an alert on staleness
+    has to be able to tell those apart."""
+    Counter.objects.all().delete()
+    cache.delete(metrics.CACHE_KEY)
+    body = scrape(client).content.decode()
+    assert 'lectern_last_scan_timestamp_seconds' not in values(body)
+    assert 'lectern_last_scan_timestamp_seconds' not in body   # not even a header
+
+
+# --- access ----------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_disabled_by_default_is_a_404(client, catalogue):
+    config.SOPDS_METRICS_ENABLE = False
+    assert scrape(client).status_code == 404
+
+
+@pytest.mark.django_db
+def test_a_configured_token_is_required(client, catalogue):
+    config.SOPDS_METRICS_TOKEN = 'sekrit'
+    assert scrape(client).status_code == 403
+    assert scrape(client, HTTP_AUTHORIZATION='Bearer wrong').status_code == 403
+    assert scrape(client, HTTP_AUTHORIZATION='Basic sekrit').status_code == 403
+    assert scrape(client, HTTP_AUTHORIZATION='Bearer sekrit').status_code == 200
+
+
+@pytest.mark.django_db
+def test_no_token_configured_means_no_token_needed(client, catalogue):
+    assert scrape(client).status_code == 200
+
+
+@pytest.mark.django_db
+def test_scraping_does_not_require_a_catalogue_login(client, catalogue):
+    """Prometheus cannot log in; SOPDS_AUTH must not gate this."""
+    config.SOPDS_AUTH = True
+    assert scrape(client).status_code == 200
+
+
+# --- cost ------------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_the_body_is_cached_between_scrapes(client, catalogue, monkeypatch):
+    """Some of these are COUNT()s over the whole book table, and scrapes are
+    frequent."""
+    first = scrape(client).content.decode()
+
+    def fail():
+        raise AssertionError('metrics were recomputed on every scrape')
+
+    monkeypatch.setattr(metrics, 'collect', fail)
+    assert scrape(client).content.decode() == first
+
+
+# --- rendering -------------------------------------------------------------
+
+def test_label_values_are_escaped():
+    body = metrics.render([('m', 'h', 'gauge', 1, {'l': 'a"b\\c'})])
+    assert 'm{l="a\\"b\\\\c"} 1' in body
+
+
+def test_a_none_value_is_omitted_entirely():
+    """Header and all, so the family does not show up as an empty one."""
+    assert metrics.render([('m', 'h', 'gauge', None, None)]) == ''
+    # A present neighbour is still rendered.
+    body = metrics.render([('gone', 'h', 'gauge', None, None),
+                           ('kept', 'h', 'gauge', 7, None)])
+    assert 'gone' not in body
+    assert values(body) == {'kept': '7'}
+
+
+def test_help_text_stays_on_one_line():
+    body = metrics.render([('m', 'two\nlines', 'gauge', 1, None)])
+    assert '# HELP m two lines' in body

--- a/sopds/health.py
+++ b/sopds/health.py
@@ -1,6 +1,10 @@
-"""Liveness/readiness probes for k8s. Unauthenticated and cheap."""
+"""Liveness/readiness probes for k8s, and the Prometheus scrape endpoint."""
 from django.db import connections
-from django.http import HttpResponse, JsonResponse
+from django.http import HttpResponse, HttpResponseForbidden, JsonResponse
+
+from constance import config
+
+from sopds import metrics
 
 
 def healthz(request):
@@ -15,3 +19,24 @@ def readyz(request):
     except Exception:
         return JsonResponse({'status': 'db-unavailable'}, status=503)
     return JsonResponse({'status': 'ok'})
+
+
+def metrics_view(request):
+    """GET /metrics — Prometheus exposition.
+
+    Off by default: it describes the size and use of the library, which is not
+    something to start publishing without being asked. `SOPDS_METRICS_ENABLE`
+    turns it on and `SOPDS_METRICS_TOKEN` optionally locks it to one scraper.
+    """
+    if not config.SOPDS_METRICS_ENABLE:
+        return HttpResponse('metrics are disabled', status=404, content_type='text/plain')
+    if not metrics.authorised(request):
+        return HttpResponseForbidden('forbidden')
+
+    up = metrics.database_up()
+    body = metrics.gather() if up else ''
+    body += metrics.render([
+        ('lectern_database_up', 'Whether the catalogue database answers.', 'gauge',
+         1 if up else 0, None),
+    ])
+    return HttpResponse(body, content_type=metrics.CONTENT_TYPE)

--- a/sopds/metrics.py
+++ b/sopds/metrics.py
@@ -1,0 +1,151 @@
+"""Prometheus metrics for the catalogue.
+
+Everything exposed here is **derived from the database on scrape**, not
+accumulated in the process. That is deliberate: the app runs under uwsgi with
+several workers, so an in-process counter would only ever describe whichever
+worker happened to answer the scrape, and making per-process counters correct
+means `prometheus_client`'s multiprocess mode — a shared writable directory,
+per-worker files and cleanup when a worker dies. Gauges read from the DB are
+the same number no matter who answers, and they are the numbers worth alerting
+on anyway: how big the catalogue is, how much is being taken out of it, and
+how long ago the scan last finished.
+
+Request-rate and latency histograms are genuinely per-process and are not here.
+They belong behind an ingress or a sidecar that already sees every request,
+rather than in a multiprocess Python app.
+
+The exposition format is written by hand rather than pulling in
+`prometheus_client`: it is a handful of gauges rendered on demand, the text
+format is small and stable, and the library's real value — the process-wide
+registry — is exactly the part that does not survive multiple workers.
+"""
+import logging
+
+from django.core.cache import cache
+from django.db import connections
+from django.db.models import Sum
+
+from constance import config
+
+logger = logging.getLogger(__name__)
+
+CONTENT_TYPE = 'text/plain; version=0.0.4; charset=utf-8'
+
+# Scrapes usually land every 15s, and some of these are COUNT()s over the whole
+# book table. Recompute at most this often; the numbers move on the timescale of
+# a scan, not of a scrape.
+CACHE_SECONDS = 30
+CACHE_KEY = 'sopds-metrics'
+
+
+def _escape_label(value):
+    """Escape a label value per the exposition format."""
+    return (str(value).replace('\\', r'\\').replace('"', r'\"').replace('\n', r'\n'))
+
+
+def render(samples):
+    """Render `[(name, help, type, value, labels)]` as the text format."""
+    lines = []
+    for name, helptext, kind, value, labels in samples:
+        # A metric with no meaningful value is left out entirely — header and
+        # all — rather than reported as zero: "no scan has ever finished" is not
+        # "the scan finished at the epoch", and an alert on staleness has to be
+        # able to tell those apart.
+        if value is None:
+            continue
+
+        rendered = ''
+        if labels:
+            rendered = '{%s}' % ','.join('%s="%s"' % (k, _escape_label(v))
+                                         for k, v in sorted(labels.items()))
+        lines.append('# HELP %s %s' % (name, helptext.replace('\n', ' ')))
+        lines.append('# TYPE %s %s' % (name, kind))
+        lines.append('%s%s %s' % (name, rendered, value))
+    return '\n'.join(lines) + '\n' if lines else ''
+
+
+def collect():
+    """Every sample, as the tuples `render` expects."""
+    from opds_catalog import models, settings
+    from opds_catalog.models import Book, BookStat, Counter, bookshelf
+
+    counter = Counter.objects
+    totals = BookStat.objects.aggregate(downloads=Sum('downloads'), reads=Sum('reads'))
+    lastscan = counter.get_lastscan()
+
+    return [
+        ('lectern_build_info', 'Version of the running code.', 'gauge', 1,
+         {'version': settings.VERSION}),
+
+        ('lectern_books_total', 'Books in the catalogue.', 'gauge',
+         counter.get_counter(models.counter_allbooks), None),
+        ('lectern_authors_total', 'Authors in the catalogue.', 'gauge',
+         counter.get_counter(models.counter_allauthors), None),
+        ('lectern_genres_total', 'Genres in the catalogue.', 'gauge',
+         counter.get_counter(models.counter_allgenres), None),
+        ('lectern_series_total', 'Series in the catalogue.', 'gauge',
+         counter.get_counter(models.counter_allseries), None),
+        ('lectern_catalogs_total', 'Directories in the catalogue.', 'gauge',
+         counter.get_counter(models.counter_allcatalogs), None),
+
+        ('lectern_books_with_isbn_total',
+         'Books whose ISBN is known, so metadata enrichment can reach them.',
+         'gauge', Book.objects.exclude(isbn='').count(), None),
+        ('lectern_books_enriched_total',
+         'Books Open Library has already been asked about.',
+         'gauge', Book.objects.filter(enriched__isnull=False).count(), None),
+        ('lectern_books_rated_total', 'Books with at least one rating.', 'gauge',
+         bookshelf.objects.filter(rating__isnull=False).values('book').distinct().count(),
+         None),
+
+        ('lectern_downloads_total', 'Book downloads served, all time.', 'counter',
+         totals['downloads'] or 0, None),
+        ('lectern_reads_total', 'Books opened in the reader, all time.', 'counter',
+         totals['reads'] or 0, None),
+
+        # The one to alert on: a scan that silently stopped running is the
+        # failure mode this catalogue actually has.
+        ('lectern_last_scan_timestamp_seconds',
+         'When the last scan finished, in unix seconds. Absent if none ever has.',
+         'gauge', int(lastscan.timestamp()) if lastscan else None, None),
+    ]
+
+
+def gather():
+    """The rendered exposition text, briefly cached."""
+    body = cache.get(CACHE_KEY)
+    if body is None:
+        body = render(collect())
+        cache.set(CACHE_KEY, body, CACHE_SECONDS)
+    return body
+
+
+def database_up():
+    try:
+        connections['default'].cursor().execute('SELECT 1')
+        return True
+    except Exception:
+        logger.warning('Metrics: database is unreachable')
+        return False
+
+
+def authorised(request):
+    """True if this scrape may proceed.
+
+    A token is optional — inside a cluster the endpoint is usually only
+    reachable by the scraper — but when one is configured it is required, so a
+    metrics endpoint that is accidentally routed to the internet does not hand
+    out the shape of the library to anyone who asks.
+    """
+    token = (config.SOPDS_METRICS_TOKEN or '').strip()
+    if not token:
+        return True
+
+    header = request.META.get('HTTP_AUTHORIZATION', '')
+    scheme, _, presented = header.partition(' ')
+    if scheme.lower() != 'bearer':
+        return False
+
+    # Constant-time compare so the token cannot be recovered by timing.
+    import hmac
+    return hmac.compare_digest(presented.strip(), token)

--- a/sopds/settings.py
+++ b/sopds/settings.py
@@ -310,6 +310,9 @@ CONSTANCE_CONFIG = OrderedDict([
     ('SOPDS_OIDC_SCOPES', ('openid email profile', _('OIDC scopes (space-separated)'))),
     ('SOPDS_OIDC_BUTTON_TEXT', ('Log in with Keycloak', _('Text on the OIDC login button'))),
 
+    ('SOPDS_METRICS_ENABLE', (False, _('Expose Prometheus metrics at /metrics'))),
+    ('SOPDS_METRICS_TOKEN', ('', _('Optional bearer token required to scrape /metrics (empty = no token)'), 'password_input')),
+
     ('SOPDS_KOSYNC_ENABLE', (False, _('Enable the KOReader (kosync) progress-sync API under /kosync/'))),
     ('SOPDS_KOSYNC_ALLOW_REGISTER', (False, _('Allow KOReader self-registration via /users/create (otherwise provision the sync password from the web UI)'))),
     ('SOPDS_WEBDAV_ENABLE', (False, _('Enable the Moon+ Reader WebDAV sync endpoint under /dav/'))),
@@ -327,6 +330,7 @@ CONSTANCE_CONFIG_FIELDSETS = {
     '7. Log & PID Files': ('SOPDS_SERVER_LOG', 'SOPDS_SCANNER_LOG', 'SOPDS_TELEBOT_LOG','SOPDS_SERVER_PID','SOPDS_SCANNER_PID','SOPDS_TELEBOT_PID'),
     '8. OIDC (Keycloak)': ('SOPDS_OIDC_ENABLE', 'SOPDS_OIDC_ISSUER', 'SOPDS_OIDC_CLIENT_ID', 'SOPDS_OIDC_CLIENT_SECRET', 'SOPDS_OIDC_SCOPES', 'SOPDS_OIDC_BUTTON_TEXT'),
     '9. Reading Progress Sync': ('SOPDS_KOSYNC_ENABLE', 'SOPDS_KOSYNC_ALLOW_REGISTER', 'SOPDS_WEBDAV_ENABLE', 'SOPDS_WEBDAV_ROOT'),
+    '10. Monitoring': ('SOPDS_METRICS_ENABLE', 'SOPDS_METRICS_TOKEN'),
 }
 
 

--- a/sopds/urls.py
+++ b/sopds/urls.py
@@ -25,6 +25,7 @@ from sopds import health
 urlpatterns = [
     re_path(r'^healthz/?$', health.healthz),
     re_path(r'^readyz/?$', health.readyz),
+    re_path(r'^metrics/?$', health.metrics_view),
     re_path(r'^opds/', include('opds_catalog.urls', namespace='opds')),
     re_path(r'^web/', include('sopds_web_backend.urls', namespace='web')),
     re_path(r'^kosync/', include('sopds_sync.kosync_urls', namespace='kosync')),


### PR DESCRIPTION
The only observability was a liveness and a readiness probe. A deployment could not answer how big the catalogue is, how much is being taken out of it, or **whether the scan is still running** — which is the failure this catalogue actually has, because a scan that quietly stops says nothing at all.

`/metrics`, off by default (`SOPDS_METRICS_ENABLE`), optional bearer token (`SOPDS_METRICS_TOKEN`).

## Why DB-derived gauges, not in-process counters

The app runs several uwsgi workers, so an in-process counter describes only whichever worker answered the scrape. Making per-process counters correct means `prometheus_client`'s multiprocess mode — a shared writable directory, per-worker files, cleanup when a worker dies. A gauge read from the DB is the same number no matter who answers, and these are the numbers worth alerting on.

Per-request latency and rate are genuinely per-process and are **not** here; they belong to an ingress or sidecar that already sees every request.

The exposition text is written by hand rather than adding `prometheus_client`: a dozen gauges rendered on demand, a small stable format, and the library's real value is the process-wide registry — exactly the part that does not survive multiple workers.

## What is exposed

`lectern_build_info`, catalogue sizes (books/authors/genres/series/catalogs), `books_with_isbn`, `books_enriched`, `books_rated`, `downloads_total`, `reads_total`, `last_scan_timestamp_seconds`, `database_up`.

**`lectern_last_scan_timestamp_seconds` is omitted entirely — header and all — when no scan has ever finished.** "Never scanned" is not "scanned at the epoch", and an alert on staleness has to be able to tell those apart.

## Cost

The body is cached for 30s: several gauges are `COUNT()`s over the whole book table, and scrapes are frequent.

## Tests

`opds_catalog/tests/test_metrics.py`: 16 tests — content type, every sample having HELP/TYPE, counts matching the catalogue, build info, download/read totals, zero vs absent, the scan timestamp, disabled-by-default 404, token enforcement (wrong token, wrong scheme, correct), scraping not requiring a catalogue login, the cache, label escaping, omitted families and one-line HELP.

476 tests pass, ruff clean.