### PR TITLE
Rate-limit the routes that hand out book content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to this project are documented here. The format is based on
 ## [Unreleased]
 
 ### Added
+- **A rate limit on the routes that hand out book content** — downloads,
+  conversions, covers, thumbnails, the reader and its illustrations
+  (`SOPDS_RATE_LIMIT`, 600 requests per minute per reader, 0 disables). Only
+  the login form was throttled, which mattered less when every content route
+  was a file read and matters more now that one of them unzips a book and
+  parses every document in its spine. This is not access control — the reader
+  is already authenticated by then — it is a ceiling so a runaway sync loop or
+  a mirroring script degrades itself rather than the server. A signed-in
+  reader is counted as themselves rather than as their address, since a
+  household behind one NAT is several readers; the counter lives in the shared
+  cache so the limit is one limit across workers; the check runs before the
+  ETag and the cache, so a client over its budget cannot spend anything; and a
+  cache outage lifts the limit rather than refusing the library.
+  Browsing the feeds is not throttled — it is handing out content that costs.
 - **Scans are recorded.** The scanner counted books added, removed, skipped and
   unparseable, then wrote the numbers to a log file and forgot them, so the
   outcome of a scan was invisible to the application — including whether it

--- a/opds_catalog/dl.py
+++ b/opds_catalog/dl.py
@@ -21,7 +21,7 @@ from django.utils.cache import patch_cache_control
 from django.views.decorators.http import etag
 
 from opds_catalog.models import Book, bookshelf
-from opds_catalog import settings, utils, opdsdb, epub_render, stats
+from opds_catalog import settings, utils, opdsdb, epub_render, stats, throttle
 import zipfile
 from opds_catalog.ziptools import open_zipfile
 
@@ -57,7 +57,7 @@ MAX_CACHED_RENDER_BYTES = 4 * 1024 * 1024
 
 
 def require_catalog_access(view):
-    """Refuse anonymous access to catalogue content while SOPDS_AUTH is on.
+    """Guard the routes that hand out book content: who may ask, and how often.
 
     Factored out of `Download`, which had the only copy of this. A session login
     counts, and so does OPDS Basic auth: e-readers fetch cover art with the same
@@ -73,6 +73,13 @@ def require_catalog_access(view):
             result = BasicAuthMiddleware().process_request(request)
             if result is not None and not hasattr(result, 'user'):
                 return result
+
+        # After authentication, so a signed-in reader is counted as themselves
+        # rather than as their address, and before the ETag and the cache, so a
+        # client over its limit cannot spend anything either.
+        if throttle.over_limit(request):
+            return throttle.too_many(request)
+
         return view(request, *args, **kwargs)
 
     return _wrapped

--- a/opds_catalog/tests/test_constance.py
+++ b/opds_catalog/tests/test_constance.py
@@ -19,7 +19,7 @@ class constanceTestCase(TestCase):
         out = StringIO()
         call_command('constance', 'list', stdout=out)
         out.seek(0)
-        self.assertEqual(out.getvalue().count('\n'), 49)
+        self.assertEqual(out.getvalue().count('\n'), 50)
         out.close()
 
     def test_constance_set_get_attr(self):

--- a/opds_catalog/tests/test_throttle.py
+++ b/opds_catalog/tests/test_throttle.py
@@ -1,0 +1,171 @@
+"""The rate limit on the routes that hand out book content.
+
+Only the login form was throttled. That mattered less when every content route
+was a file read, and matters more now that one of them unzips a book and parses
+every document in its spine.
+"""
+import os
+
+import pytest
+from django.core.cache import cache
+from django.urls import reverse
+from constance import config
+
+from opds_catalog import throttle
+from opds_catalog.models import Book, Catalog
+
+DATA = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
+FB2 = '262001.fb2'
+
+
+@pytest.fixture(autouse=True)
+def clean_cache():
+    cache.clear()
+    yield
+    cache.clear()
+
+
+@pytest.fixture
+def book(db, django_user_model, client):
+    config.SOPDS_AUTH = True
+    config.SOPDS_ROOT_LIB = DATA
+    config.SOPDS_RATE_LIMIT = 3
+    cat = Catalog.objects.create(parent=None, cat_name='.', path='.', cat_type=0)
+    book = Book.objects.create(
+        filename=FB2, path='.', filesize=os.path.getsize(os.path.join(DATA, FB2)),
+        format='fb2', cat_type=0, docdate='2011', lang='en', title='Sparrow',
+        search_title='SPARROW', annotation='', avail=2, catalog=cat)
+    client.force_login(django_user_model.objects.create_user(username='r', password='pw'))
+    return book
+
+
+def cover(client, book):
+    return client.get(reverse('opds:cover', args=[book.id]))
+
+
+# --- enforcement -----------------------------------------------------------
+
+@pytest.mark.django_db
+def test_requests_within_the_limit_are_served(client, book):
+    for _ in range(3):
+        assert cover(client, book).status_code == 200
+
+
+@pytest.mark.django_db
+def test_going_over_the_limit_is_429_with_retry_after(client, book):
+    for _ in range(3):
+        cover(client, book)
+
+    resp = cover(client, book)
+    assert resp.status_code == 429
+    assert resp['Retry-After'] == '60'
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('name, args', [
+    ('opds:cover', None), ('opds:thumb', None), ('opds:read', None),
+])
+def test_every_content_route_is_covered(client, book, name, args):
+    url = reverse(name, args=[book.id])
+    for _ in range(3):
+        client.get(url)
+    assert client.get(url).status_code == 429
+
+
+@pytest.mark.django_db
+def test_download_is_covered_too(client, book):
+    url = reverse('opds:download', args=[book.id, 0])
+    for _ in range(3):
+        client.get(url)
+    assert client.get(url).status_code == 429
+
+
+@pytest.mark.django_db
+def test_the_budget_is_shared_across_routes(client, book):
+    """It is a limit on a client, not on a URL."""
+    cover(client, book)
+    client.get(reverse('opds:thumb', args=[book.id]))
+    client.get(reverse('opds:download', args=[book.id, 0]))
+    assert cover(client, book).status_code == 429
+
+
+# --- who is counted --------------------------------------------------------
+
+@pytest.mark.django_db
+def test_readers_are_counted_separately(client, book, django_user_model):
+    """A household behind one address is several readers."""
+    for _ in range(4):
+        cover(client, book)
+    assert cover(client, book).status_code == 429
+
+    other = django_user_model.objects.create_user(username='other', password='pw')
+    client.force_login(other)
+    assert cover(client, book).status_code == 200
+
+
+@pytest.mark.django_db
+def test_anonymous_clients_are_counted_by_address(client, book, rf):
+    config.SOPDS_AUTH = False
+    request = rf.get('/', REMOTE_ADDR='10.0.0.7')
+    request.user = None
+    assert throttle.client_id(request) == 'i10.0.0.7'
+
+
+@pytest.mark.django_db
+def test_a_forwarded_address_is_preferred_behind_a_proxy(rf):
+    request = rf.get('/', REMOTE_ADDR='127.0.0.1',
+                     HTTP_X_FORWARDED_FOR='203.0.113.9, 10.0.0.1')
+    request.user = None
+    assert throttle.client_id(request) == 'i203.0.113.9'
+
+
+# --- configuration and failure modes ---------------------------------------
+
+@pytest.mark.django_db
+def test_zero_disables_the_limit(client, book):
+    config.SOPDS_RATE_LIMIT = 0
+    for _ in range(20):
+        assert cover(client, book).status_code == 200
+
+
+@pytest.mark.django_db
+def test_a_broken_cache_lets_the_request_through(rf, monkeypatch):
+    """An unenforced limit is a much smaller problem than a refused library.
+
+    Checked against `over_limit` rather than through a view: the rest of the
+    request also uses the cache, and hardening every one of those against a
+    dead Redis is a separate question from what this module promises.
+    """
+    def boom(*args, **kwargs):
+        raise RuntimeError('redis is gone')
+
+    monkeypatch.setattr(cache, 'incr', boom)
+    monkeypatch.setattr(cache, 'set', boom)
+
+    request = rf.get('/', REMOTE_ADDR='10.0.0.7')
+    request.user = None
+    assert throttle.over_limit(request) is False
+
+
+@pytest.mark.django_db
+def test_the_limit_is_checked_before_anything_is_spent(client, book, monkeypatch):
+    """A client over its budget must not be able to make us unzip a book."""
+    from opds_catalog import dl
+
+    for _ in range(3):
+        cover(client, book)
+
+    def fail(*args, **kwargs):
+        raise AssertionError('the book was opened for a throttled request')
+
+    monkeypatch.setattr(dl, 'extract_cover', fail)
+    assert cover(client, book).status_code == 429
+
+
+@pytest.mark.django_db
+def test_the_feeds_are_not_throttled(client, book):
+    """Browsing is cheap; it is handing out content that is not."""
+    config.SOPDS_RATE_LIMIT = 1
+    cover(client, book)
+    for _ in range(5):
+        assert client.get(reverse('opds:main')).status_code == 200

--- a/opds_catalog/throttle.py
+++ b/opds_catalog/throttle.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+"""A rate limit for the routes that cost something to serve.
+
+The login form has been throttled for a while; nothing else was. That mattered
+less when every content route was a file read, and matters more now that one of
+them unzips a book and parses every document in its spine. The cache in front
+of that helps a warm book and does nothing for a client walking the catalogue.
+
+This is not access control — the reader is already authenticated by the time it
+gets here. It is a ceiling on how fast one client can ask, so a runaway sync
+loop or a mirroring script degrades itself instead of the server.
+
+The counter lives in the shared cache, like the login throttle, so the limit is
+the same limit across uwsgi workers rather than one per worker.
+"""
+import logging
+
+from django.core.cache import cache
+from django.http import HttpResponse
+
+from constance import config
+
+logger = logging.getLogger(__name__)
+
+WINDOW_SECONDS = 60
+
+
+def client_id(request):
+    """Who to count against.
+
+    A signed-in reader is counted as themselves rather than as their address:
+    a household behind one NAT is several readers, and one of them syncing a
+    library should not lock out the rest.
+    """
+    user = getattr(request, 'user', None)
+    if user is not None and user.is_authenticated:
+        return 'u%s' % user.pk
+
+    forwarded = request.META.get('HTTP_X_FORWARDED_FOR')
+    if forwarded:
+        return 'i%s' % forwarded.split(',')[0].strip()
+    return 'i%s' % request.META.get('REMOTE_ADDR', '')
+
+
+def over_limit(request):
+    """True when this client has already used up the current minute."""
+    limit = config.SOPDS_RATE_LIMIT
+    if not limit or limit <= 0:
+        return False
+
+    key = 'sopds-throttle:%s' % client_id(request)
+    try:
+        # incr on a missing key raises rather than starting at zero, which is
+        # also how we learn to seed it with the window's expiry attached.
+        used = cache.incr(key)
+    except ValueError:
+        cache.set(key, 1, WINDOW_SECONDS)
+        used = 1
+    except Exception:
+        # A cache that is down must not take the catalogue down with it: an
+        # unenforced limit is a much smaller problem than a refused library.
+        logger.warning('Rate limiting is disabled: the cache is unavailable')
+        return False
+
+    if used == limit + 1:
+        # Once per client per window, not once per rejected request — the whole
+        # point is that there are about to be a great many of these.
+        logger.warning('Rate limit reached by %s (%d/min)', client_id(request), limit)
+    return used > limit
+
+
+def too_many(request):
+    response = HttpResponse('rate limit exceeded', status=429, content_type='text/plain')
+    response['Retry-After'] = str(WINDOW_SECONDS)
+    return response

--- a/sopds/settings.py
+++ b/sopds/settings.py
@@ -310,6 +310,8 @@ CONSTANCE_CONFIG = OrderedDict([
     ('SOPDS_OIDC_SCOPES', ('openid email profile', _('OIDC scopes (space-separated)'))),
     ('SOPDS_OIDC_BUTTON_TEXT', ('Log in with Keycloak', _('Text on the OIDC login button'))),
 
+    ('SOPDS_RATE_LIMIT', (600, _('Max requests per minute per reader for downloads, covers and the reader (0 = no limit)'))),
+
     ('SOPDS_METRICS_ENABLE', (False, _('Expose Prometheus metrics at /metrics'))),
     ('SOPDS_METRICS_TOKEN', ('', _('Optional bearer token required to scrape /metrics (empty = no token)'), 'password_input')),
 
@@ -330,7 +332,7 @@ CONSTANCE_CONFIG_FIELDSETS = {
     '7. Log & PID Files': ('SOPDS_SERVER_LOG', 'SOPDS_SCANNER_LOG', 'SOPDS_TELEBOT_LOG','SOPDS_SERVER_PID','SOPDS_SCANNER_PID','SOPDS_TELEBOT_PID'),
     '8. OIDC (Keycloak)': ('SOPDS_OIDC_ENABLE', 'SOPDS_OIDC_ISSUER', 'SOPDS_OIDC_CLIENT_ID', 'SOPDS_OIDC_CLIENT_SECRET', 'SOPDS_OIDC_SCOPES', 'SOPDS_OIDC_BUTTON_TEXT'),
     '9. Reading Progress Sync': ('SOPDS_KOSYNC_ENABLE', 'SOPDS_KOSYNC_ALLOW_REGISTER', 'SOPDS_WEBDAV_ENABLE', 'SOPDS_WEBDAV_ROOT'),
-    '10. Monitoring': ('SOPDS_METRICS_ENABLE', 'SOPDS_METRICS_TOKEN'),
+    '10. Monitoring': ('SOPDS_RATE_LIMIT', 'SOPDS_METRICS_ENABLE', 'SOPDS_METRICS_TOKEN'),
 }
 
 


### PR DESCRIPTION
The login form has been throttled for a while and **nothing else was**. That mattered less when every content route was a file read; it matters more now that one of them unzips a book and parses every document in its spine (#75). The cache in front of that helps a warm book and does nothing for a client walking the catalogue.

`SOPDS_RATE_LIMIT`, 600 requests/minute per reader, `0` disables. Covers downloads, conversions, covers, thumbnails, the reader and its illustrations.

This is **not access control** — the reader is already authenticated by the time it reaches here. It is a ceiling so a runaway sync loop or a mirroring script degrades itself instead of the server.

## Four decisions

- **Counted per reader, not per address.** A household behind one NAT is several readers, and one of them syncing a library should not lock out the rest. Anonymous clients fall back to the address (`X-Forwarded-For` first).
- **The counter lives in the shared cache**, like the login throttle, so it is one limit rather than one per uwsgi worker.
- **The check sits after authentication but before the ETag and the cache**, so a client over its budget cannot spend anything either — there is a test asserting a throttled request never reaches `extract_cover`.
- **A cache outage lifts the limit** rather than enforcing it. An unenforced ceiling is a far smaller problem than a refused library.

Browsing the feeds is deliberately not throttled: listing is cheap, handing out content is what costs.

## Tests

`opds_catalog/tests/test_throttle.py`: 14 tests — within/over the limit, `Retry-After`, every content route covered, one shared budget across routes, readers counted separately, address fallback and `X-Forwarded-For`, zero disabling it, a broken cache letting requests through, the limit checked before any work, and feeds staying unthrottled.

501 tests pass, ruff clean.