### PR TITLE
Tag every request with a correlation id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to this project are documented here. The format is based on
 ## [Unreleased]
 
 ### Added
+- **A correlation id on every request.** Several uwsgi workers interleave their
+  output and an e-reader polling feeds produces a great deal of it, so a report
+  of "a download failed a few minutes ago" had to be matched against the log by
+  guesswork. Each request now carries an id: taken from `X-Request-ID` when
+  something upstream already set one, so an ingress that stamps requests keeps
+  the same value end to end, generated otherwise; returned in the response
+  header; tagged onto the Sentry scope; and printed on every log line emitted
+  while handling the request. An inbound value is length-limited and stripped
+  of anything unusual before it is used — it is attacker-supplied and ends up
+  in log records, where a newline turns one record into two.
 - **A rate limit on the routes that hand out book content** — downloads,
   conversions, covers, thumbnails, the reader and its illustrations
   (`SOPDS_RATE_LIMIT`, 600 requests per minute per reader, 0 disables). Only

--- a/opds_catalog/tests/test_request_id.py
+++ b/opds_catalog/tests/test_request_id.py
@@ -1,0 +1,138 @@
+"""A correlation id on every request, in the logs and back to the caller."""
+import logging
+
+import pytest
+from django.urls import reverse
+
+from sopds import request_id
+from sopds.request_id import HEADER, RequestIDFilter, RequestIDMiddleware, sanitize
+
+
+# --- the header ------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_every_response_carries_an_id(client):
+    resp = client.get('/healthz')
+    assert resp[HEADER]
+    assert len(resp[HEADER]) >= 8
+
+
+@pytest.mark.django_db
+def test_two_requests_get_different_ids(client):
+    first = client.get('/healthz')[HEADER]
+    second = client.get('/healthz')[HEADER]
+    assert first != second
+
+
+@pytest.mark.django_db
+def test_an_upstream_id_is_kept(client):
+    """An ingress that stamps requests should see the same value end to end."""
+    resp = client.get('/healthz', headers={'x-request-id': 'edge-abc123'})
+    assert resp[HEADER] == 'edge-abc123'
+
+
+@pytest.mark.django_db
+def test_an_id_survives_an_error_response(client):
+    """The responses worth correlating are exactly the ones that went wrong."""
+    resp = client.get(reverse('opds:cover', args=[999999]))
+    assert resp.status_code in (401, 404)
+    assert resp[HEADER]
+
+
+# --- untrusted input -------------------------------------------------------
+
+@pytest.mark.parametrize('given, expected', [
+    ('plain-123', 'plain-123'),
+    ('  spaced  ', 'spaced'),
+    ('a b c', 'abc'),
+    ('drop\nnewline', 'dropnewline'),
+    ('semi;colon', 'semicolon'),
+    ('', None),
+    ('   ', None),
+    (None, None),
+    ('!!!', None),
+])
+def test_a_caller_supplied_id_is_cleaned(given, expected):
+    assert sanitize(given) == expected
+
+
+def test_an_overlong_id_is_truncated():
+    assert len(sanitize('x' * 500)) == 64
+
+
+@pytest.mark.django_db
+def test_a_newline_in_the_header_cannot_forge_a_log_line(client):
+    """It ends up in log records; a newline there turns one record into two."""
+    resp = client.get('/healthz', headers={'x-request-id': 'good\nINFO fake line'})
+    assert '\n' not in resp[HEADER]
+    assert resp[HEADER] == 'goodINFOfakeline'
+
+
+@pytest.mark.django_db
+def test_an_unusable_id_falls_back_to_a_generated_one(client):
+    resp = client.get('/healthz', headers={'x-request-id': '!!!!'})
+    assert resp[HEADER] and resp[HEADER] != '!!!!'
+
+
+# --- logging ---------------------------------------------------------------
+
+def test_the_filter_tags_records_outside_a_request():
+    record = logging.LogRecord('n', logging.INFO, __file__, 1, 'msg', (), None)
+    assert RequestIDFilter().filter(record) is True
+    assert record.request_id == '-'
+
+
+def test_log_lines_emitted_during_a_request_carry_its_id():
+    """The whole point: a line in the log can be traced back to one request.
+
+    Asserted on the formatted output, because the tag is applied by the filter
+    at the moment the record is handled — inspecting the record afterwards, once
+    the request has finished, only ever shows the out-of-request placeholder.
+    """
+    import io
+    from django.http import HttpResponse
+    from django.test import RequestFactory
+
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.addFilter(RequestIDFilter())
+    handler.setFormatter(logging.Formatter('[%(request_id)s] %(message)s'))
+
+    log = logging.getLogger('opds_catalog.test_request_id')
+    log.addHandler(handler)
+    log.propagate = False
+    try:
+        def view(request):
+            log.warning('something happened')
+            return HttpResponse('ok')
+
+        response = RequestIDMiddleware(view)(RequestFactory().get('/'))
+        log.warning('after the request')
+    finally:
+        log.removeHandler(handler)
+
+    during, after = stream.getvalue().strip().splitlines()
+    assert during == '[%s] something happened' % response[HEADER]
+    assert after == '[-] after the request'
+
+
+def test_the_id_is_cleared_after_the_request():
+    """Otherwise a worker's next request inherits the previous one's id."""
+    from django.http import HttpResponse
+    from django.test import RequestFactory
+
+    middleware = RequestIDMiddleware(lambda r: HttpResponse('ok'))
+    middleware(RequestFactory().get('/'))
+    assert request_id.get() == '-'
+
+
+def test_the_id_is_cleared_even_when_the_view_raises(monkeypatch):
+    from django.test import RequestFactory
+
+    def boom(request):
+        raise RuntimeError('view exploded')
+
+    middleware = RequestIDMiddleware(boom)
+    with pytest.raises(RuntimeError):
+        middleware(RequestFactory().get('/'))
+    assert request_id.get() == '-'

--- a/sopds/request_id.py
+++ b/sopds/request_id.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+"""A correlation id for every request, in the logs and back to the caller.
+
+Without one, a report of "a download failed a few minutes ago" has to be matched
+against the log by guesswork — several uwsgi workers interleave their lines, and
+an e-reader polling feeds produces a lot of them. With one, the id in the
+response header names exactly the lines to look at.
+
+The id is taken from `X-Request-ID` when something upstream already set one, so
+an ingress that stamps requests keeps the same value end to end, and generated
+otherwise. An inbound value is length-limited and stripped of anything unusual:
+it is attacker-supplied and ends up in log lines, and a newline in a log line is
+how one record becomes two.
+"""
+import logging
+import re
+import uuid
+from contextvars import ContextVar
+
+HEADER = 'X-Request-ID'
+META_KEY = 'HTTP_X_REQUEST_ID'
+
+MAX_LENGTH = 64
+SAFE = re.compile(r'[^A-Za-z0-9._:-]')
+
+# A ContextVar rather than thread-local storage: it is what Django's own async
+# support uses, so this keeps working if a view is ever handled off the request
+# thread.
+_current = ContextVar('request_id', default='-')
+
+
+def get():
+    """The current request's id, or '-' outside a request."""
+    return _current.get()
+
+
+def sanitize(value):
+    """A caller-supplied id, made safe to put in a log line."""
+    cleaned = SAFE.sub('', (value or '').strip())[:MAX_LENGTH]
+    return cleaned or None
+
+
+class RequestIDMiddleware:
+    """Assign an id to the request, echo it, and expose it to logging."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        request_id = sanitize(request.META.get(META_KEY)) or uuid.uuid4().hex
+        request.request_id = request_id
+        token = _current.set(request_id)
+
+        # Tag the Sentry scope too, so an event and a log line can be lined up
+        # from either direction. Sentry is optional, and never worth an error.
+        try:
+            import sentry_sdk
+            sentry_sdk.set_tag('request_id', request_id)
+        except Exception:
+            pass
+
+        try:
+            response = self.get_response(request)
+        finally:
+            _current.reset(token)
+
+        response[HEADER] = request_id
+        return response
+
+
+class RequestIDFilter(logging.Filter):
+    """Put `request_id` on every record so a formatter can print it.
+
+    A filter rather than an adapter because it has to reach records emitted by
+    Django and by libraries, which know nothing about this.
+    """
+
+    def filter(self, record):
+        record.request_id = get()
+        return True

--- a/sopds/settings.py
+++ b/sopds/settings.py
@@ -67,6 +67,9 @@ if SENTRY_DSN:
 # commented out) — pure overhead — so it is removed. Performance-sensitive shared
 # fragments are cached explicitly instead (see sopds_web_backend.views).
 MIDDLEWARE = [
+    # First, so every later middleware and every log line emitted while handling
+    # the request can see the id — including responses the rest never reaches.
+    'sopds.request_id.RequestIDMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -232,6 +235,42 @@ else:
             'LOCATION': 'sopds-locmem',
         }
     }
+
+# Logging: tag every line with the request it belongs to. Several uwsgi workers
+# interleave their output and an e-reader polling feeds produces a lot of it, so
+# without the tag a report of "a download failed a few minutes ago" has to be
+# matched against the log by guesswork.
+#
+# Only the loggers that emit during a request are redirected here, each with
+# propagate=False so they are not also printed by whatever is attached to the
+# root logger — the scanner attaches a file handler there at runtime, and a line
+# arriving twice is worse than a line arriving plainly.
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'filters': {
+        'request_id': {'()': 'sopds.request_id.RequestIDFilter'},
+    },
+    'formatters': {
+        'tagged': {
+            'format': '%(asctime)s %(levelname)-8s [%(request_id)s] %(name)s: %(message)s',
+        },
+    },
+    'handlers': {
+        'tagged_console': {
+            'class': 'logging.StreamHandler',
+            'filters': ['request_id'],
+            'formatter': 'tagged',
+        },
+    },
+    'loggers': {
+        'django.request': {'handlers': ['tagged_console'], 'level': 'WARNING', 'propagate': False},
+        'opds_catalog': {'handlers': ['tagged_console'], 'level': 'INFO', 'propagate': False},
+        'sopds_sync': {'handlers': ['tagged_console'], 'level': 'INFO', 'propagate': False},
+        'sopds.metrics': {'handlers': ['tagged_console'], 'level': 'INFO', 'propagate': False},
+        'sopds_web_backend': {'handlers': ['tagged_console'], 'level': 'INFO', 'propagate': False},
+    },
+}
 
 CACHE_MIDDLEWARE_KEY_PREFIX = "sopds"
 


### PR DESCRIPTION
Several uwsgi workers interleave their output, and an e-reader polling feeds produces a great deal of it, so a report of *"a download failed a few minutes ago"* had to be matched against the log by guesswork.

## Changes

Each request carries an id, which is:

- taken from `X-Request-ID` when something upstream already set one, so an ingress that stamps requests keeps the same value end to end — generated otherwise;
- returned in the response header, including on error responses, which are exactly the ones worth correlating;
- tagged onto the Sentry scope, so an event and a log line line up from either direction;
- printed on every log line emitted while the request is handled.

## Two details

**An inbound id is untrusted.** It is length-limited and stripped down to a conservative character set before it is used anywhere, because its destination is a log record and a newline there is how one record becomes two. There is a test for exactly that forgery.

**The logging config redirects only the loggers that emit during a request**, each with `propagate=False`, so their lines are not *also* printed by whatever is attached to the root logger — the scanner attaches a file handler there at runtime, and a line arriving twice is worse than a line arriving plainly.

The id lives in a `ContextVar` (the same mechanism Django's async support uses) and is reset in a `finally`, so a worker's next request cannot inherit the previous one's id even if a view raises.

## Tests

`opds_catalog/tests/test_request_id.py`: 20 tests — a header on every response, ids differing between requests, an upstream id preserved, an id on error responses, nine sanitisation cases, truncation, the newline forgery, fallback for an unusable value, the filter outside a request, a log line carrying the id of the request that emitted it (asserted on the formatted output), and the id being cleared afterwards including when the view raises.

521 tests pass, ruff clean.