### PR TITLE
Survive an unreachable cache instead of 500ing on it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+### Fixed
+- **An unreachable Redis no longer returns 500 for every page.** Django's
+  `RedisCache` lets connection errors out, and the catalogue reads the cache in
+  a dozen places — cover bytes, rendered EPUBs, the alphabet menu, the stats
+  block on every page, the metrics body, the OIDC discovery document, both
+  throttles — so an outage in something whose only job is to make requests
+  faster took the site down with it. Found while testing the rate limit: the
+  throttle handled a dead cache and the cover view behind it did not.
+  A `ResilientRedisCache` backend now degrades every operation to what it would
+  do against an empty cache — reads miss, writes vanish — which callers already
+  handle. Two consequences, deliberate and worth knowing: while the cache is
+  down neither the login lockout nor the content rate limit is enforced, and
+  covers and EPUBs are re-rendered per request. `lectern_cache_up` reports the
+  state so the degradation is visible rather than merely survivable.
+
 ### Added
 - **A correlation id on every request.** Several uwsgi workers interleave their
   output and an e-reader polling feeds produces a great deal of it, so a report

--- a/opds_catalog/tests/test_cache_resilience.py
+++ b/opds_catalog/tests/test_cache_resilience.py
@@ -1,0 +1,197 @@
+"""A cache outage must degrade the catalogue, not take it down.
+
+Django's RedisCache lets connection errors out, so with Redis unreachable every
+`cache.get` in a view raised and the page 500'd — for something that exists
+purely to make requests faster.
+"""
+import os
+
+import pytest
+from django.core.cache.backends.redis import RedisCache
+from django.test import override_settings
+from django.urls import reverse
+from constance import config
+
+from opds_catalog.models import Book, Catalog
+from sopds.cache import ResilientRedisCache, _redis_errors
+
+DATA = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
+FB2 = '262001.fb2'
+
+
+# OSError, not a synthetic exception: it is what a socket failure actually
+# raises, it is in the caught tuple whether or not redis-py is importable, and
+# using the real thing means the test exercises the same path production will.
+def failing(*args, **kwargs):
+    raise OSError('connection refused')
+
+
+@pytest.fixture
+def backend():
+    """A resilient backend without a real Redis behind it."""
+    instance = ResilientRedisCache.__new__(ResilientRedisCache)
+    instance._errors = _redis_errors()
+    return instance
+
+
+@pytest.fixture
+def dead(backend, monkeypatch):
+    for name in ('get', 'get_many', 'set', 'set_many', 'add', 'touch',
+                 'delete', 'delete_many', 'has_key', 'incr', 'clear'):
+        monkeypatch.setattr(RedisCache, name, failing)
+    return backend
+
+
+# --- the backend contract --------------------------------------------------
+
+def test_a_read_misses_rather_than_raising(dead):
+    assert dead.get('k') is None
+    assert dead.get('k', 'fallback') == 'fallback'
+    assert dead.get_many(['a', 'b']) == {}
+
+
+def test_a_write_vanishes_rather_than_raising(dead):
+    assert dead.set('k', 1) is False
+    assert dead.add('k', 1) is False
+    assert dead.touch('k') is False
+    assert dead.set_many({'a': 1, 'b': 2}) == ['a', 'b']
+
+
+def test_deletes_and_probes_do_not_raise(dead):
+    assert dead.delete('k') is False
+    assert dead.delete_many(['a']) is None
+    assert dead.has_key('k') is False
+    assert dead.clear() is None
+
+
+def test_incr_raises_the_missing_key_error(dead):
+    """Which is what both counters already handle: it is how they seed a
+    window, so a dead cache makes every request look like the first."""
+    with pytest.raises(ValueError):
+        dead.incr('k')
+
+
+def test_an_unrelated_error_is_not_swallowed(backend, monkeypatch):
+    """Only "the cache is not answering" is survivable; a bug is not."""
+    def bug(*args, **kwargs):
+        raise TypeError('programming error')
+
+    monkeypatch.setattr(RedisCache, 'get', bug)
+    with pytest.raises(TypeError):
+        backend.get('k')
+
+
+def test_a_working_backend_is_left_alone(backend, monkeypatch):
+    monkeypatch.setattr(RedisCache, 'get', lambda self, k, d=None, v=None: 'value')
+    monkeypatch.setattr(RedisCache, 'set', lambda self, k, val, t=None, v=None, **kw: True)
+    assert backend.get('k') == 'value'
+    assert backend.set('k', 1) is True
+
+
+# --- what the views do -----------------------------------------------------
+
+@pytest.fixture
+def book(db, django_user_model, client):
+    config.SOPDS_AUTH = True
+    config.SOPDS_ROOT_LIB = DATA
+    config.SOPDS_RATE_LIMIT = 0
+    cat = Catalog.objects.create(parent=None, cat_name='.', path='.', cat_type=0)
+    book = Book.objects.create(
+        filename=FB2, path='.', filesize=os.path.getsize(os.path.join(DATA, FB2)),
+        format='fb2', cat_type=0, docdate='2011', lang='en', title='Sparrow',
+        search_title='SPARROW', annotation='', avail=2, catalog=cat)
+    client.force_login(django_user_model.objects.create_user(username='r', password='pw'))
+    return book
+
+
+# The resilience lives in the Redis backend subclass, so exercising it through a
+# view means actually configuring that backend — patching the LocMem cache the
+# tests otherwise use would prove nothing about production.
+resilient_cache = override_settings(CACHES={'default': {
+    'BACKEND': 'sopds.cache.ResilientRedisCache',
+    'LOCATION': 'redis://127.0.0.1:6379',   # never connected to; see `broken_cache`
+}})
+
+
+@pytest.fixture
+def broken_cache(monkeypatch):
+    """Configure the resilient backend and make the Redis under it unreachable."""
+    for name in ('get', 'get_many', 'set', 'set_many', 'add', 'touch',
+                 'delete', 'delete_many', 'has_key', 'incr', 'clear'):
+        monkeypatch.setattr(RedisCache, name, failing)
+    with resilient_cache:
+        yield
+
+
+@pytest.mark.django_db
+def test_a_cover_is_still_served_without_a_cache(client, book, broken_cache):
+    """It was a 500 before: the throttle in front handled a dead cache and the
+    cover view behind it did not."""
+    resp = client.get(reverse('opds:cover', args=[book.id]))
+    assert resp.status_code == 200
+    assert resp['Content-Type'] == 'image/jpeg'
+
+
+@pytest.mark.django_db
+def test_a_page_is_still_served_without_a_cache(client, book, broken_cache):
+    assert client.get(reverse('web:main')).status_code == 200
+
+
+@pytest.mark.django_db
+def test_a_download_is_still_served_without_a_cache(client, book, broken_cache):
+    assert client.get(reverse('opds:download', args=[book.id, 0])).status_code == 200
+
+
+@pytest.mark.django_db
+def test_login_still_works_without_a_cache(client, book, broken_cache):
+    """The lockout counter lives in the cache; losing it must not lock the door
+    instead of merely failing to bolt it."""
+    client.logout()
+    resp = client.post(reverse('web:login'), {'username': 'r', 'password': 'pw'})
+    assert resp.status_code == 302
+
+
+@pytest.mark.django_db
+def test_a_wrong_password_still_gets_the_normal_refusal(client, book, broken_cache):
+    """403, the same as always — not a 500 from the throttle behind it."""
+    client.logout()
+    resp = client.post(reverse('web:login'), {'username': 'r', 'password': 'wrong'})
+    assert resp.status_code == 403
+
+
+@pytest.mark.django_db
+def test_the_lockout_is_simply_not_enforced_while_the_cache_is_down(client, book, broken_cache):
+    """Stated because it is a real consequence, not an accident: a cache outage
+    is also a window with no brute-force protection on the login form."""
+    client.logout()
+    for _ in range(15):        # well past LOGIN_RATE_LIMIT
+        client.post(reverse('web:login'), {'username': 'r', 'password': 'wrong'})
+
+    resp = client.post(reverse('web:login'), {'username': 'r', 'password': 'pw'})
+    assert resp.status_code == 302
+
+
+# --- visibility ------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_metrics_report_the_cache_as_down(client, broken_cache):
+    """A degraded cache does not stop the catalogue serving, so nothing else
+    would report it."""
+    config.SOPDS_METRICS_ENABLE = True
+    config.SOPDS_METRICS_TOKEN = ''
+    body = client.get('/metrics').content.decode()
+    assert 'lectern_cache_up 0' in body
+
+
+@pytest.mark.django_db
+def test_metrics_report_a_healthy_cache(client, db):
+    config.SOPDS_METRICS_ENABLE = True
+    config.SOPDS_METRICS_TOKEN = ''
+    body = client.get('/metrics').content.decode()
+    assert 'lectern_cache_up 1' in body
+
+
+def test_the_caught_errors_always_include_socket_failures():
+    """redis-py may not be importable (it is only needed where it is used), and
+    the backend must still catch the errors a dead socket produces."""
+    assert OSError in _redis_errors()

--- a/sopds/cache.py
+++ b/sopds/cache.py
@@ -1,0 +1,170 @@
+# -*- coding: utf-8 -*-
+"""A Redis cache backend that degrades instead of failing the request.
+
+Django's `RedisCache` lets connection errors out, so with Redis unreachable
+every `cache.get` in a view raises and the page 500s. The catalogue leans on the
+cache in a dozen places — cover bytes, rendered EPUBs, the alphabet menu, the
+stats block on every page, the metrics body, the OIDC discovery document, both
+throttles — so an outage in something that exists purely to make things faster
+took the whole site down with it. That was found while testing the rate limit:
+the throttle handled a dead cache, and the cover view behind it did not.
+
+Every operation here behaves, on a backend failure, exactly as it would against
+an empty cache: reads miss, writes vanish. Callers already handle both, because
+a cache may legitimately not have what they asked for.
+
+Two consequences worth stating plainly rather than discovering later:
+
+* Both throttles — the login lockout and the content rate limit — count in this
+  cache, so while it is down neither is enforced. That is the same trade the
+  rate limit already documents: an unenforced ceiling is a smaller problem than
+  a library nobody can reach. It does mean a Redis outage is also a window with
+  no brute-force protection on the login form, which is worth alerting on.
+* Cover extraction and EPUB rendering stop being cached, so the server does the
+  full work per request. Slow, but serving.
+
+`lectern_cache_up` in the metrics reports the state, so the degradation is
+visible rather than merely survivable.
+"""
+import logging
+
+from django.core.cache.backends.redis import RedisCache
+
+logger = logging.getLogger(__name__)
+
+
+def _redis_errors():
+    """The exception types that mean "the cache is not answering".
+
+    Imported lazily and defensively: redis is only installed where it is used,
+    and the backend must not fail to import without it.
+    """
+    try:
+        from redis import exceptions
+        return (exceptions.RedisError, OSError)
+    except Exception:      # pragma: no cover - redis is a declared dependency
+        return (OSError,)
+
+
+class ResilientRedisCache(RedisCache):
+    """`RedisCache`, but an unreachable Redis is a miss rather than a 500."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._errors = _redis_errors()
+
+    def _degrade(self, operation, err):
+        # warning, not exception: an outage produces one of these per request,
+        # and a stack trace on each would bury everything else in the log.
+        logger.warning('Cache unavailable, %s degraded: %s', operation, err)
+
+    def get(self, key, default=None, version=None):
+        try:
+            return super().get(key, default, version)
+        except self._errors as err:
+            self._degrade('get', err)
+            return default
+
+    def get_many(self, keys, version=None):
+        try:
+            return super().get_many(keys, version)
+        except self._errors as err:
+            self._degrade('get_many', err)
+            return {}
+
+    def set(self, key, value, timeout=None, version=None, **kwargs):
+        try:
+            return super().set(key, value, timeout, version, **kwargs)
+        except self._errors as err:
+            self._degrade('set', err)
+            return False
+
+    def set_many(self, data, timeout=None, version=None):
+        try:
+            return super().set_many(data, timeout, version)
+        except self._errors as err:
+            self._degrade('set_many', err)
+            return list(data)          # "none of these were stored"
+
+    def add(self, key, value, timeout=None, version=None):
+        try:
+            return super().add(key, value, timeout, version)
+        except self._errors as err:
+            self._degrade('add', err)
+            return False
+
+    def touch(self, key, timeout=None, version=None):
+        try:
+            return super().touch(key, timeout, version)
+        except self._errors as err:
+            self._degrade('touch', err)
+            return False
+
+    def delete(self, key, version=None):
+        try:
+            return super().delete(key, version)
+        except self._errors as err:
+            self._degrade('delete', err)
+            return False
+
+    def delete_many(self, keys, version=None):
+        try:
+            return super().delete_many(keys, version)
+        except self._errors as err:
+            self._degrade('delete_many', err)
+
+    def has_key(self, key, version=None):
+        try:
+            return super().has_key(key, version)
+        except self._errors as err:
+            self._degrade('has_key', err)
+            return False
+
+    def incr(self, key, delta=1, version=None):
+        """Raise ValueError on an outage, which is what "no such key" raises.
+
+        Both counters that use `incr` already handle that — it is how they seed
+        a new window — so a dead cache makes every request look like the first
+        one of its window, and nothing accumulates. Deliberate: see the module
+        docstring.
+        """
+        try:
+            return super().incr(key, delta, version)
+        except self._errors as err:
+            self._degrade('incr', err)
+            raise ValueError('cache unavailable') from err
+
+    def clear(self):
+        try:
+            return super().clear()
+        except self._errors as err:
+            self._degrade('clear', err)
+
+
+def is_up():
+    """Whether the shared cache is answering right now.
+
+    Deliberately does not use the resilient wrapper's swallowing: this is the
+    one caller that wants the truth rather than a graceful default.
+    """
+    from django.core.cache import DEFAULT_CACHE_ALIAS, caches
+
+    # `caches[...]`, not `django.core.cache.cache`: that name is a proxy object,
+    # so an isinstance check against it is always False and this would report a
+    # dead cache as healthy.
+    backend = caches[DEFAULT_CACHE_ALIAS]
+
+    probe = 'sopds-cache-probe'
+    try:
+        # A round trip, not just a connect: a Redis that accepts connections and
+        # then refuses writes (out of memory, a read-only replica) is not up for
+        # our purposes.
+        if isinstance(backend, ResilientRedisCache):
+            # Straight to the parent, bypassing the swallowing above — this is
+            # the one caller that wants the error rather than a graceful miss.
+            RedisCache.set(backend, probe, 1, 10)
+        else:
+            backend.set(probe, 1, 10)
+        return True
+    except Exception:
+        return False

--- a/sopds/health.py
+++ b/sopds/health.py
@@ -38,5 +38,10 @@ def metrics_view(request):
     body += metrics.render([
         ('lectern_database_up', 'Whether the catalogue database answers.', 'gauge',
          1 if up else 0, None),
+        # A degraded cache does not stop the catalogue serving, so nothing else
+        # reports it; without this it is invisible until someone notices the
+        # latency. It is also a window with no brute-force protection on login.
+        ('lectern_cache_up', 'Whether the shared cache answers.', 'gauge',
+         1 if metrics.cache_up() else 0, None),
     ])
     return HttpResponse(body, content_type=metrics.CONTENT_TYPE)

--- a/sopds/metrics.py
+++ b/sopds/metrics.py
@@ -153,6 +153,11 @@ def gather():
     return body
 
 
+def cache_up():
+    from sopds import cache as cache_backend
+    return cache_backend.is_up()
+
+
 def database_up():
     try:
         connections['default'].cursor().execute('SELECT 1')

--- a/sopds/settings.py
+++ b/sopds/settings.py
@@ -224,7 +224,8 @@ USE_TZ = True
 if os.getenv('REDIS_URL'):
     CACHES = {
         'default': {
-            'BACKEND': 'django.core.cache.backends.redis.RedisCache',
+            # Degrades to a miss instead of 500ing the request; see sopds/cache.py.
+            'BACKEND': 'sopds.cache.ResilientRedisCache',
             'LOCATION': os.getenv('REDIS_URL'),
         }
     }


### PR DESCRIPTION
Django's `RedisCache` lets connection errors out, so with Redis unreachable every `cache.get` in a view raised and the page failed. The catalogue reads the cache in a dozen places — cover bytes, rendered EPUBs, the alphabet menu, the stats block on **every page render**, the metrics body, the OIDC discovery document, both throttles — and exactly one of them, the rate limit, guarded itself.

So an outage in the component whose only job is to make requests faster took the whole site down with it.

It surfaced while testing #86: the throttle handled a dead cache and the cover view immediately behind it did not.

## Fixed at the backend, not the call sites

Eighteen call sites, one of them guarded. A `ResilientRedisCache` subclass fixes all of them and everything written later. Each operation degrades to what it would do against an empty cache — reads miss, writes vanish — which callers already handle, because a cache may legitimately not have what was asked for.

`incr` raises the same `ValueError` a missing key raises, which is exactly what both counters already handle: it is how they seed a new window.

Errors that are **not** "the cache is not answering" still propagate. A bug is not something to survive.

## Two deliberate consequences

Stated in the module rather than left to be discovered:

- **While the cache is down neither throttle counts**, so a Redis outage is also a window with no brute-force protection on the login form. Worth alerting on. (An unenforced ceiling is still a smaller problem than a library nobody can reach.)
- **Covers and EPUBs are re-rendered per request.** Slow, but serving.

`lectern_cache_up` reports the state, because a degraded cache does not stop the catalogue answering and nothing else would show it.

## A bug in the health probe itself

`is_up()` resolves the backend through `caches[...]` rather than the `django.core.cache.cache` proxy — an `isinstance` check against the proxy is always False, which had the first version cheerfully reporting a dead cache as healthy.

## Tests

`opds_catalog/tests/test_cache_resilience.py`: 15 tests — the full backend contract (read, write, delete, probe, incr), unrelated errors still raising, a working backend untouched, and through real views: cover, page, download and login all served with the cache dead, the wrong-password path still returning its normal 403, the lockout demonstrably not enforced, and both metric states.

536 tests pass, ruff clean.