### PR TITLE
Add an export and restore for data a rescan cannot rebuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+### Added
+- **`sopds_userdata_export` / `sopds_userdata_import`** — a backup for the part
+  of the database a rescan cannot rebuild: shelves, statuses, ratings, reading
+  positions, progress synced from e-readers, reader preferences, download and
+  read counters, and the ISBNs, publishers, annotations and dates
+  `sopds_enrich` fetched at the cost of a request each.
+  `dumpdata` does not serve here. Every one of those tables points at `Book` by
+  id, and a rebuilt catalogue assigns different ids, so a restored shelf would
+  name the wrong books. The export keys on identity that survives a rebuild
+  instead: the `(path, filename)` pair the scanner itself uses to recognise a
+  book, falling back to the content digest for a book renamed since. Restoring
+  never overwrites what is already there unless `--force`, so it is safe
+  against a live catalogue and not only into an empty one; counters only ever
+  go up; and anything that cannot be matched is counted and reported rather
+  than guessed at.
+
 ### Fixed
 - **An unreachable Redis no longer returns 500 for every page.** Django's
   `RedisCache` lets connection errors out, and the catalogue reads the cache in

--- a/opds_catalog/management/commands/sopds_userdata_export.py
+++ b/opds_catalog/management/commands/sopds_userdata_export.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+#
+# Write out the part of the database a rescan cannot rebuild: shelves, reading
+# progress, usage counters and the metadata sopds_enrich fetched.
+#
+# See sopds.userdata for why `dumpdata` does not serve here — every one of those
+# tables points at Book by id, and a rebuilt catalogue assigns different ids.
+#
+# python manage.py sopds_userdata_export --output backup.json
+import json
+import sys
+
+from django.core.management.base import BaseCommand
+
+from sopds import userdata
+
+
+class Command(BaseCommand):
+    help = 'Export shelves, reading progress, usage counters and enriched metadata.'
+
+    def add_arguments(self, parser):
+        parser.add_argument('--output', default='-',
+                            help='File to write to; "-" (the default) is stdout.')
+        parser.add_argument('--indent', type=int, default=1,
+                            help='JSON indentation. 0 for the most compact output.')
+
+    def handle(self, *args, **options):
+        payload = userdata.export()
+        text = json.dumps(payload, ensure_ascii=False,
+                          indent=options['indent'] or None, sort_keys=True)
+
+        if options['output'] == '-':
+            self.stdout.write(text)
+        else:
+            with open(options['output'], 'w', encoding='utf-8') as handle:
+                handle.write(text)
+
+        # To stderr, so it cannot end up inside the JSON when piping to a file.
+        print('Exported %d book record(s), %d shelf row(s), %d theme(s), '
+              '%d kosync row(s).'
+              % (len(payload['books']), len(payload['shelves']),
+                 len(payload['themes']), len(payload['kosync'])), file=sys.stderr)

--- a/opds_catalog/management/commands/sopds_userdata_import.py
+++ b/opds_catalog/management/commands/sopds_userdata_import.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+#
+# Restore an export produced by sopds_userdata_export.
+#
+# Books are matched by the (path, filename) pair the scanner itself uses, with
+# the content digest as a fallback for a book renamed since; users by name.
+# Anything that cannot be matched is counted and reported rather than guessed at.
+#
+# Nothing already present is overwritten unless --force, so this is safe to run
+# against a live catalogue and not only into an empty one.
+#
+# python manage.py sopds_userdata_import backup.json [--dry-run] [--force]
+import json
+
+from django.core.management.base import BaseCommand, CommandError
+
+from sopds import userdata
+
+
+class Command(BaseCommand):
+    help = 'Restore shelves, reading progress, usage counters and enriched metadata.'
+
+    def add_arguments(self, parser):
+        parser.add_argument('path', help='The file written by sopds_userdata_export.')
+        parser.add_argument('--dry-run', action='store_true', default=False,
+                            help='Report what would be restored without writing.')
+        parser.add_argument('--force', action='store_true', default=False,
+                            help='Overwrite rows that already exist.')
+
+    def handle(self, *args, **options):
+        try:
+            with open(options['path'], encoding='utf-8') as handle:
+                payload = json.load(handle)
+        except (OSError, ValueError) as err:
+            raise CommandError('Cannot read %s: %s' % (options['path'], err))
+
+        try:
+            stats = userdata.load(payload, force=options['force'],
+                                  dry_run=options['dry_run'])
+        except ValueError as err:
+            raise CommandError(str(err))
+
+        prefix = 'DRY-RUN: ' if options['dry_run'] else ''
+        self.stdout.write(
+            '%sRestored %d book record(s), %d shelf row(s), %d theme(s), '
+            '%d kosync row(s). Left alone: %d. '
+            'Books not in this catalogue: %d, unknown users: %d.'
+            % (prefix, stats['books'], stats['shelves'], stats['themes'],
+               stats['kosync'], stats['skipped'],
+               stats['unknown_books'], stats['unknown_users']))

--- a/opds_catalog/tests/test_userdata.py
+++ b/opds_catalog/tests/test_userdata.py
@@ -1,0 +1,272 @@
+"""Exporting and restoring the part of the database a rescan cannot rebuild.
+
+The point of the whole thing is the round trip through a *rebuilt* catalogue,
+where every book has a different id — which is exactly what `dumpdata` cannot
+survive.
+"""
+import io
+import json
+import os
+
+import pytest
+from django.core.management import call_command
+from django.utils import timezone
+
+from opds_catalog.models import Book, BookStat, Catalog, Theme, bookshelf
+from sopds import userdata
+from sopds_sync.models import BookDigest, KosyncProgress
+
+DATA = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
+
+
+@pytest.fixture
+def populated(db, django_user_model):
+    cat = Catalog.objects.create(parent=None, cat_name='.', path='.', cat_type=0)
+
+    def add(name):
+        return Book.objects.create(
+            filename=name, path='shelf', filesize=1, format='fb2', cat_type=0,
+            docdate='', lang='en', title=name, search_title=name.upper(),
+            annotation='', avail=2, catalog=cat)
+
+    first, second = add('one.fb2'), add('two.fb2')
+    first.isbn = '9780306406157'
+    first.publisher = 'Gollancz'
+    first.annotation = 'From Open Library.'
+    first.enriched = timezone.now()
+    first.save()
+
+    reader = django_user_model.objects.create_user(username='reader', password='pw')
+    bookshelf.objects.create(user=reader, book=first, status=bookshelf.STATUS_READING,
+                             rating=4, percent=0.42, position='2.13')
+    Theme.objects.create(user=reader, theme_css='css/sopds-dark.css', font_size=120)
+    BookStat.objects.create(book=first, downloads=7, reads=3)
+    KosyncProgress.objects.create(user=reader, document='d' * 32,
+                                  progress='xpointer', percentage=0.5)
+    return {'cat': cat, 'first': first, 'second': second, 'reader': reader}
+
+
+def rebuild(catalog, names=('one.fb2', 'two.fb2'), path='shelf'):
+    """Throw the catalogue away and rescan it, so every book gets a new id."""
+    Book.objects.all().delete()
+    made = []
+    for name in names:
+        made.append(Book.objects.create(
+            filename=name, path=path, filesize=1, format='fb2', cat_type=0,
+            docdate='', lang='en', title=name, search_title=name.upper(),
+            annotation='', avail=2, catalog=catalog))
+    return made
+
+
+# --- export ----------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_export_carries_each_kind_of_user_data(populated):
+    payload = userdata.export()
+    assert payload['version'] == userdata.VERSION
+    assert len(payload['shelves']) == 1
+    assert len(payload['themes']) == 1
+    assert len(payload['kosync']) == 1
+    assert len(payload['books']) == 1        # only the enriched/read one
+
+
+@pytest.mark.django_db
+def test_export_identifies_books_by_something_that_survives_a_rebuild(populated):
+    shelf = userdata.export()['shelves'][0]
+    assert shelf['path'] == 'shelf'
+    assert shelf['filename'] == 'one.fb2'
+    assert 'id' not in shelf
+
+
+@pytest.mark.django_db
+def test_export_skips_books_that_carry_nothing(populated):
+    """A book with no enrichment and no reads is fully rebuilt by a scan."""
+    exported = {b['filename'] for b in userdata.export()['books']}
+    assert exported == {'one.fb2'}
+
+
+@pytest.mark.django_db
+def test_export_is_json_serialisable(populated):
+    json.dumps(userdata.export())
+
+
+# --- the round trip that matters -------------------------------------------
+
+@pytest.mark.django_db
+def test_a_rebuilt_catalogue_gets_its_user_data_back(populated):
+    payload = userdata.export()
+    old_id = populated['first'].id
+
+    new_first, _ = rebuild(populated['cat'])
+    assert new_first.id != old_id      # ids really did change
+    assert not bookshelf.objects.exists()
+
+    userdata.load(payload)
+
+    shelf = bookshelf.objects.get()
+    assert shelf.book_id == new_first.id
+    assert shelf.status == bookshelf.STATUS_READING
+    assert shelf.rating == 4
+    assert shelf.percent == pytest.approx(0.42)
+    assert shelf.position == '2.13'
+
+
+@pytest.mark.django_db
+def test_enrichment_survives_a_rebuild(populated):
+    """Each of those fields cost a request to somebody else's API."""
+    payload = userdata.export()
+    rebuild(populated['cat'])
+
+    userdata.load(payload)
+
+    book = Book.objects.get(filename='one.fb2')
+    assert book.isbn == '9780306406157'
+    assert book.publisher == 'Gollancz'
+    assert book.annotation == 'From Open Library.'
+    assert book.enriched is not None
+
+
+@pytest.mark.django_db
+def test_counters_survive_a_rebuild(populated):
+    payload = userdata.export()
+    rebuild(populated['cat'])
+    userdata.load(payload)
+
+    stat = BookStat.objects.get()
+    assert (stat.downloads, stat.reads) == (7, 3)
+
+
+@pytest.mark.django_db
+def test_theme_and_kosync_progress_survive(populated):
+    payload = userdata.export()
+    rebuild(populated['cat'])
+    userdata.load(payload)
+
+    assert Theme.objects.get().font_size == 120
+    assert KosyncProgress.objects.get().percentage == pytest.approx(0.5)
+
+
+# --- matching --------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_a_renamed_book_is_found_by_its_content_digest(populated):
+    """The (path, filename) pair does not survive a rename; the digest does."""
+    BookDigest.objects.create(book=populated['first'], digest='a' * 32,
+                              method=BookDigest.BINARY)
+    payload = userdata.export()
+    assert payload['shelves'][0]['digest'] == 'a' * 32
+
+    renamed, = rebuild(populated['cat'], names=('renamed.fb2',))
+    BookDigest.objects.create(book=renamed, digest='a' * 32, method=BookDigest.BINARY)
+
+    userdata.load(payload)
+    assert bookshelf.objects.get().book_id == renamed.id
+
+
+@pytest.mark.django_db
+def test_a_book_no_longer_in_the_catalogue_is_counted_not_guessed_at(populated):
+    payload = userdata.export()
+    rebuild(populated['cat'], names=('something-else.fb2',))
+
+    stats = userdata.load(payload)
+    assert stats['unknown_books'] >= 1
+    assert not bookshelf.objects.exists()
+
+
+@pytest.mark.django_db
+def test_an_unknown_user_is_counted_not_created(populated, django_user_model):
+    payload = userdata.export()
+    django_user_model.objects.filter(username='reader').delete()
+
+    stats = userdata.load(payload)
+    assert stats['unknown_users'] >= 1
+    assert not django_user_model.objects.filter(username='reader').exists()
+
+
+# --- restoring onto a live catalogue ---------------------------------------
+
+@pytest.mark.django_db
+def test_an_existing_shelf_row_is_left_alone(populated):
+    """Safe to run against a live catalogue, not only into an empty one."""
+    payload = userdata.export()
+    bookshelf.objects.update(rating=1, status=bookshelf.STATUS_READ)
+
+    stats = userdata.load(payload)
+    assert stats['skipped'] >= 1
+    assert bookshelf.objects.get().rating == 1
+
+
+@pytest.mark.django_db
+def test_force_overwrites_it(populated):
+    payload = userdata.export()
+    bookshelf.objects.update(rating=1)
+
+    userdata.load(payload, force=True)
+    assert bookshelf.objects.get().rating == 4
+
+
+@pytest.mark.django_db
+def test_enrichment_already_present_is_not_replaced(populated):
+    payload = userdata.export()
+    Book.objects.filter(filename='one.fb2').update(publisher='From the file')
+
+    userdata.load(payload)
+    assert Book.objects.get(filename='one.fb2').publisher == 'From the file'
+
+
+@pytest.mark.django_db
+def test_counters_only_ever_go_up(populated):
+    """Importing an old export must not erase what has been counted since."""
+    payload = userdata.export()
+    BookStat.objects.update(downloads=100)
+
+    userdata.load(payload)
+    assert BookStat.objects.get().downloads == 100
+
+
+@pytest.mark.django_db
+def test_dry_run_writes_nothing(populated):
+    payload = userdata.export()
+    rebuild(populated['cat'])
+
+    stats = userdata.load(payload, dry_run=True)
+    assert stats['shelves'] == 1
+    assert not bookshelf.objects.exists()
+
+
+@pytest.mark.django_db
+def test_an_unknown_version_is_refused(populated):
+    with pytest.raises(ValueError):
+        userdata.load({'version': 999})
+
+
+# --- the commands ----------------------------------------------------------
+
+@pytest.mark.django_db
+def test_the_commands_round_trip_through_a_file(populated, tmp_path):
+    path = tmp_path / 'backup.json'
+    call_command('sopds_userdata_export', '--output', str(path))
+    assert path.exists()
+
+    rebuild(populated['cat'])
+    out = io.StringIO()
+    call_command('sopds_userdata_import', str(path), stdout=out)
+
+    assert 'Restored' in out.getvalue()
+    assert bookshelf.objects.get().rating == 4
+
+
+@pytest.mark.django_db
+def test_export_to_stdout_is_valid_json_on_its_own(populated):
+    """The summary goes to stderr so it cannot end up inside a redirected file."""
+    out = io.StringIO()
+    call_command('sopds_userdata_export', stdout=out)
+    payload = json.loads(out.getvalue())
+    assert payload['version'] == userdata.VERSION
+
+
+@pytest.mark.django_db
+def test_importing_a_missing_file_is_an_error_not_a_traceback(populated):
+    from django.core.management.base import CommandError
+    with pytest.raises(CommandError):
+        call_command('sopds_userdata_import', '/nonexistent/backup.json')

--- a/sopds/userdata.py
+++ b/sopds/userdata.py
@@ -1,0 +1,287 @@
+# -*- coding: utf-8 -*-
+"""Export and restore the part of the database a rescan cannot rebuild.
+
+Almost everything in the catalogue is derived: drop the database, run a scan,
+and the books, authors, series and genres come back. These do not.
+
+* what readers did — shelves, statuses, ratings, reading positions, progress
+  synced from an e-reader, per-user reader preferences;
+* what the library was used for — download and read counts;
+* what enrichment cost — the ISBNs, publishers, annotations and dates
+  `sopds_enrich` fetched, each of which was a request to somebody else's API.
+
+`dumpdata` does not solve this. Every one of those tables points at `Book` by
+id, and a rebuilt catalogue assigns different ids, so a restored shelf would
+name the wrong books. This keys on identity that survives a rebuild instead:
+the (path, filename) pair the scanner itself uses to recognise a book, with the
+content digest as a fallback for a book that has since been renamed or moved.
+
+Restoring never overwrites. A row that is already there is left alone unless
+`force` is given, which makes an import safe to run against a live catalogue
+and not only into an empty one.
+"""
+import logging
+
+from django.contrib.auth.models import User
+from django.utils import timezone
+from django.utils.dateparse import parse_datetime
+
+from opds_catalog.models import Book, BookStat, Theme, bookshelf
+
+logger = logging.getLogger(__name__)
+
+VERSION = 1
+
+
+def _iso(value):
+    return value.isoformat() if value else None
+
+
+def _book_key(book_digests, book):
+    """How a book will be found again after the catalogue is rebuilt."""
+    return {
+        'path': book.path,
+        'filename': book.filename,
+        # Survives a rename, unlike the pair above, but only exists once
+        # `sopds_kosync_index` has run.
+        'digest': book_digests.get(book.id),
+    }
+
+
+def _content_digests():
+    """{book_id: digest} for the books that have a content hash indexed."""
+    try:
+        from sopds_sync.models import BookDigest
+    except Exception:      # pragma: no cover - the app is always installed
+        return {}
+
+    return dict(BookDigest.objects
+                .filter(method=BookDigest.BINARY)
+                .values_list('book_id', 'digest'))
+
+
+def export():
+    """Everything worth keeping, as a plain JSON-serialisable dict."""
+    digests = _content_digests()
+    books = {b.id: b for b in Book.objects.all()}
+
+    payload = {
+        'version': VERSION,
+        'exported': _iso(timezone.now()),
+        'books': [],
+        'shelves': [],
+        'themes': [],
+        'kosync': [],
+    }
+
+    # Enrichment results and usage counters, per book.
+    stats = {s.book_id: s for s in BookStat.objects.all()}
+    for book in books.values():
+        stat = stats.get(book.id)
+        entry = _book_key(digests, book)
+        entry.update({
+            'isbn': book.isbn,
+            'publisher': book.publisher,
+            'annotation': book.annotation,
+            'docdate': book.docdate,
+            'enriched': _iso(book.enriched),
+            'downloads': stat.downloads if stat else 0,
+            'reads': stat.reads if stat else 0,
+        })
+        # A book with nothing enriched and nothing read carries no information
+        # a rescan would not produce anyway.
+        if any((entry['isbn'], entry['publisher'], entry['annotation'],
+                entry['docdate'], entry['enriched'], entry['downloads'], entry['reads'])):
+            payload['books'].append(entry)
+
+    for row in bookshelf.objects.select_related('user', 'book'):
+        entry = _book_key(digests, row.book)
+        entry.update({
+            'user': row.user.username,
+            'status': row.status,
+            'rating': row.rating,
+            'percent': row.percent,
+            'position': row.position,
+            'readtime': _iso(row.readtime),
+        })
+        payload['shelves'].append(entry)
+
+    for theme in Theme.objects.select_related('user'):
+        payload['themes'].append({
+            'user': theme.user.username,
+            'theme_css': theme.theme_css,
+            'reader_mode': theme.reader_mode,
+            'font_size': theme.font_size,
+        })
+
+    try:
+        from sopds_sync.models import KosyncProgress
+        for row in KosyncProgress.objects.select_related('user'):
+            payload['kosync'].append({
+                'user': row.user.username,
+                # Already a stable content hash computed by the client — the one
+                # identifier here that needs no translation at all.
+                'document': row.document,
+                'progress': row.progress,
+                'percentage': row.percentage,
+                'device': row.device,
+                'device_id': row.device_id,
+                'timestamp': _iso(row.timestamp),
+            })
+    except Exception:      # pragma: no cover
+        logger.exception('Could not export kosync progress')
+
+    return payload
+
+
+class Importer:
+    """Restores an export, matching books and users by name rather than id."""
+
+    def __init__(self, payload, force=False, dry_run=False):
+        self.payload = payload
+        self.force = force
+        self.dry_run = dry_run
+        self.stats = {'books': 0, 'shelves': 0, 'themes': 0, 'kosync': 0,
+                      'unknown_books': 0, 'unknown_users': 0, 'skipped': 0}
+
+        self._by_path = {(b.path, b.filename): b for b in Book.objects.all()}
+        self._by_digest = {}
+        for book_id, digest in _content_digests().items():
+            self._by_digest[digest] = book_id
+        self._books = {b.id: b for b in Book.objects.all()}
+        self._users = {u.username: u for u in User.objects.all()}
+
+    def find_book(self, entry):
+        """The book this entry refers to in *this* catalogue, or None."""
+        book = self._by_path.get((entry.get('path'), entry.get('filename')))
+        if book is not None:
+            return book
+
+        # Renamed or moved since the export: fall back to content.
+        digest = entry.get('digest')
+        if digest:
+            book_id = self._by_digest.get(digest)
+            if book_id is not None:
+                return self._books.get(book_id)
+        return None
+
+    def find_user(self, username):
+        return self._users.get(username)
+
+    def run(self):
+        self._books_and_stats()
+        self._shelves()
+        self._themes()
+        self._kosync()
+        return self.stats
+
+    def _books_and_stats(self):
+        for entry in self.payload.get('books', []):
+            book = self.find_book(entry)
+            if book is None:
+                self.stats['unknown_books'] += 1
+                continue
+
+            changed = {}
+            for field in ('isbn', 'publisher', 'annotation', 'docdate'):
+                value = entry.get(field)
+                if value and (self.force or not getattr(book, field)):
+                    changed[field] = value
+            enriched = parse_datetime(entry.get('enriched') or '') if entry.get('enriched') else None
+            if enriched and (self.force or book.enriched is None):
+                changed['enriched'] = enriched
+
+            if changed:
+                self.stats['books'] += 1
+                if not self.dry_run:
+                    Book.objects.filter(pk=book.pk).update(**changed)
+
+            downloads, reads = entry.get('downloads') or 0, entry.get('reads') or 0
+            if (downloads or reads) and not self.dry_run:
+                stat, _ = BookStat.objects.get_or_create(book=book)
+                # Counters only ever go up: importing an old export into a live
+                # catalogue must not erase what has been counted since.
+                BookStat.objects.filter(book=book).update(
+                    downloads=max(stat.downloads, downloads),
+                    reads=max(stat.reads, reads))
+
+    def _shelves(self):
+        for entry in self.payload.get('shelves', []):
+            user = self.find_user(entry.get('user'))
+            if user is None:
+                self.stats['unknown_users'] += 1
+                continue
+            book = self.find_book(entry)
+            if book is None:
+                self.stats['unknown_books'] += 1
+                continue
+
+            existing = bookshelf.objects.filter(user=user, book=book).first()
+            if existing is not None and not self.force:
+                self.stats['skipped'] += 1
+                continue
+
+            self.stats['shelves'] += 1
+            if self.dry_run:
+                continue
+
+            readtime = parse_datetime(entry.get('readtime') or '') or timezone.now()
+            bookshelf.objects.update_or_create(
+                user=user, book=book,
+                defaults={'status': entry.get('status') or '',
+                          'rating': entry.get('rating'),
+                          'percent': entry.get('percent'),
+                          'position': entry.get('position'),
+                          'readtime': readtime})
+
+    def _themes(self):
+        for entry in self.payload.get('themes', []):
+            user = self.find_user(entry.get('user'))
+            if user is None:
+                self.stats['unknown_users'] += 1
+                continue
+            if Theme.objects.filter(user=user).exists() and not self.force:
+                self.stats['skipped'] += 1
+                continue
+
+            self.stats['themes'] += 1
+            if not self.dry_run:
+                Theme.objects.update_or_create(
+                    user=user,
+                    defaults={'theme_css': entry.get('theme_css') or 'css/sopds.css',
+                              'reader_mode': entry.get('reader_mode') or Theme.READER_WHOLE,
+                              'font_size': entry.get('font_size') or 100})
+
+    def _kosync(self):
+        from sopds_sync.models import KosyncProgress
+
+        for entry in self.payload.get('kosync', []):
+            user = self.find_user(entry.get('user'))
+            if user is None:
+                self.stats['unknown_users'] += 1
+                continue
+            document = entry.get('document')
+            if not document:
+                continue
+            if KosyncProgress.objects.filter(user=user, document=document).exists() \
+                    and not self.force:
+                self.stats['skipped'] += 1
+                continue
+
+            self.stats['kosync'] += 1
+            if not self.dry_run:
+                KosyncProgress.objects.update_or_create(
+                    user=user, document=document,
+                    defaults={'progress': entry.get('progress') or '',
+                              'percentage': entry.get('percentage') or 0.0,
+                              'device': entry.get('device') or '',
+                              'device_id': entry.get('device_id') or '',
+                              'timestamp': parse_datetime(entry.get('timestamp') or '')
+                              or timezone.now()})
+
+
+def load(payload, force=False, dry_run=False):
+    version = payload.get('version')
+    if version != VERSION:
+        raise ValueError('unsupported export version %r (expected %d)' % (version, VERSION))
+    return Importer(payload, force=force, dry_run=dry_run).run()


### PR DESCRIPTION
Almost everything in the catalogue is derived: drop the database, run a scan, and the books, authors, series and genres come back. **Three things do not.**

- What readers did — shelves, statuses, ratings, positions, progress synced from an e-reader, reader preferences.
- What the library was used for — the download and read counters.
- What enrichment cost — the ISBNs, publishers, annotations and dates, each of which was a request to somebody else's API.

Until now the only protection for any of it was a backup of the whole database.

## Why not `dumpdata`

This is the reason the command exists at all. Every one of those tables points at `Book` **by id**, and a rebuilt catalogue assigns different ids — so a restored shelf would name the wrong books.

The export keys on identity that survives a rebuild: the `(path, filename)` pair the scanner itself uses to recognise a book, falling back to the **content digest** from the kosync index for a book renamed since. The round trip through a rebuilt catalogue, where every id has changed, is what the tests actually exercise.

## Restoring fills, it does not replace

- A row already present is left alone unless `--force`.
- **Counters only ever move up**, so importing an old export cannot erase what has been counted since.
- A book or user that cannot be matched is counted and reported, not guessed at.

That makes this usable against a live catalogue and not only into an empty one.

Books carrying neither enrichment nor a read are left out of the export entirely — a scan reproduces them exactly.

## Usage

```
python manage.py sopds_userdata_export --output backup.json
python manage.py sopds_userdata_import backup.json [--dry-run] [--force]
```

The export summary goes to stderr, so piping stdout to a file yields valid JSON on its own.

## Tests

`opds_catalog/tests/test_userdata.py`: 20 tests — each kind of data exported, id-free identity, empty books skipped, the full round trip through a rebuilt catalogue for shelves/enrichment/counters/theme/kosync, a renamed book found by digest, unmatched books and users counted, existing rows left alone, `--force`, counters not going down, dry run, version check, and both commands through a real file.

556 tests pass, ruff clean.