### PR TITLE
Let readers manage their own accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,26 @@ All notable changes to this project are documented here. The format is based on
   go up; and anything that cannot be matched is counted and reported rather
   than guessed at.
 
+### Added
+- **Self-service accounts.** A password could only be changed, and an account
+  only created, through the Django admin — fine for one administrator and
+  constant friction for everyone else, since a reader who forgot their password
+  had to find a human. There is now a change-password form linked from the
+  settings page, a forgotten-password flow linked from the login page, and an
+  optional registration form (`SOPDS_ALLOW_REGISTRATION`, off by default,
+  because a form left open on the internet is a way to acquire strangers).
+  The reset and confirm steps are Django's own views wearing this project's
+  chrome: token generation and expiry are where the security lives and are not
+  worth reimplementing. The reset form reports the same thing for a known and
+  an unknown address, so it cannot be used to find out who has an account, and
+  it is hidden entirely when mail is not configured rather than offering
+  something that cannot work. Registration and reset share a per-client
+  throttle — both make work for someone else.
+- **Mail is configured in the admin**, like everything else an operator has to
+  set here: host, port, credentials, STARTTLS/SSL and the From address, through
+  a backend that reads them at connection time. A password reset that does not
+  arrive is then diagnosed and fixed without a redeploy.
+
 ### Changed
 - The **Top rated** listing no longer costs more as the library grows. It
   aggregated over every book and then discarded almost all of them with a

--- a/opds_catalog/tests/test_accounts.py
+++ b/opds_catalog/tests/test_accounts.py
@@ -1,0 +1,239 @@
+"""Self-service accounts: change a password, reset a forgotten one, register.
+
+All three used to require an administrator with admin access.
+"""
+import pytest
+from django.core import mail as django_mail
+from django.core.cache import cache
+from django.urls import reverse
+from constance import config
+
+
+@pytest.fixture(autouse=True)
+def clean(db):
+    cache.clear()
+    config.SOPDS_AUTH = True
+    config.SOPDS_ALLOW_REGISTRATION = False
+    config.SOPDS_SMTP_HOST = 'smtp.example.com'
+    config.SOPDS_MAIL_FROM = 'library@example.com'
+    yield
+    cache.clear()
+
+
+@pytest.fixture
+def reader(django_user_model):
+    return django_user_model.objects.create_user(
+        username='reader', password='old-password-42', email='reader@example.com')
+
+
+# --- changing a known password ---------------------------------------------
+
+@pytest.mark.django_db
+def test_a_signed_in_reader_can_change_their_password(client, reader):
+    client.force_login(reader)
+    resp = client.post(reverse('web:password_change'), {
+        'old_password': 'old-password-42',
+        'new_password1': 'a-new-password-99',
+        'new_password2': 'a-new-password-99'})
+    assert resp.status_code == 302
+
+    reader.refresh_from_db()
+    assert reader.check_password('a-new-password-99')
+
+
+@pytest.mark.django_db
+def test_the_old_password_is_required(client, reader):
+    client.force_login(reader)
+    client.post(reverse('web:password_change'), {
+        'old_password': 'not-it',
+        'new_password1': 'a-new-password-99',
+        'new_password2': 'a-new-password-99'})
+
+    reader.refresh_from_db()
+    assert reader.check_password('old-password-42')
+
+
+@pytest.mark.django_db
+def test_changing_a_password_needs_a_login(client, reader):
+    resp = client.get(reverse('web:password_change'))
+    assert resp.status_code in (302, 403)
+
+
+@pytest.mark.django_db
+def test_the_settings_page_links_to_it(client, reader):
+    client.force_login(reader)
+    body = client.get(reverse('web:settings')).content.decode()
+    assert reverse('web:password_change') in body
+
+
+# --- resetting a forgotten one ---------------------------------------------
+
+@pytest.mark.django_db
+def test_a_reset_sends_a_link(client, reader):
+    resp = client.post(reverse('web:password_reset'), {'email': 'reader@example.com'})
+    assert resp.status_code == 302
+    assert len(django_mail.outbox) == 1
+    assert reverse('web:password_reset_confirm',
+                   kwargs={'uidb64': 'x', 'token': 'y'})[:20] in django_mail.outbox[0].body
+
+
+@pytest.mark.django_db
+def test_the_link_actually_sets_a_new_password(client, reader):
+    client.post(reverse('web:password_reset'), {'email': 'reader@example.com'})
+    body = django_mail.outbox[0].body
+    link = next(line.strip() for line in body.splitlines() if '/password/reset/' in line)
+    path = link.split('://', 1)[1].split('/', 1)[1]
+
+    # Django swaps the token for a session-held one and redirects.
+    resp = client.get('/' + path, follow=True)
+    assert resp.status_code == 200
+    resp = client.post(resp.request['PATH_INFO'],
+                       {'new_password1': 'reset-password-77',
+                        'new_password2': 'reset-password-77'})
+    assert resp.status_code == 302
+
+    reader.refresh_from_db()
+    assert reader.check_password('reset-password-77')
+
+
+@pytest.mark.django_db
+def test_an_unknown_address_looks_exactly_the_same(client, reader):
+    """The form must not double as a way to find out who has an account."""
+    known = client.post(reverse('web:password_reset'), {'email': 'reader@example.com'})
+    django_mail.outbox.clear()
+    unknown = client.post(reverse('web:password_reset'), {'email': 'nobody@example.com'})
+
+    assert known.status_code == unknown.status_code == 302
+    assert known.url == unknown.url
+    assert django_mail.outbox == []
+
+
+@pytest.mark.django_db
+def test_reset_is_hidden_when_mail_is_not_configured(client, reader):
+    """An offer that cannot work is worse than no offer."""
+    config.SOPDS_SMTP_HOST = ''
+    assert client.get(reverse('web:password_reset')).status_code == 404
+    assert reverse('web:password_reset') not in client.get(reverse('web:login')).content.decode()
+
+
+@pytest.mark.django_db
+def test_reset_is_offered_on_the_login_page_when_it_can_work(client):
+    assert reverse('web:password_reset') in client.get(reverse('web:login')).content.decode()
+
+
+@pytest.mark.django_db
+def test_reset_requests_are_throttled(client, reader):
+    """It sends mail to an address the caller picks, so it is usable both to
+    spam a stranger and to probe for accounts."""
+    for _ in range(10):
+        client.post(reverse('web:password_reset'), {'email': 'reader@example.com'})
+
+    resp = client.post(reverse('web:password_reset'), {'email': 'reader@example.com'})
+    assert resp.status_code == 403
+
+
+# --- registration ----------------------------------------------------------
+
+@pytest.mark.django_db
+def test_registration_is_off_by_default(client):
+    assert client.get(reverse('web:register')).status_code == 404
+
+
+@pytest.mark.django_db
+def test_registration_is_not_advertised_while_it_is_off(client):
+    assert reverse('web:register') not in client.get(reverse('web:login')).content.decode()
+
+
+@pytest.mark.django_db
+def test_a_visitor_can_register_when_it_is_allowed(client, django_user_model):
+    config.SOPDS_ALLOW_REGISTRATION = True
+    resp = client.post(reverse('web:register'), {
+        'username': 'newcomer',
+        'password1': 'a-fresh-password-1',
+        'password2': 'a-fresh-password-1'})
+
+    assert resp.status_code == 302
+    assert django_user_model.objects.filter(username='newcomer').exists()
+
+
+@pytest.mark.django_db
+def test_registering_signs_you_in(client, django_user_model):
+    config.SOPDS_ALLOW_REGISTRATION = True
+    client.post(reverse('web:register'), {
+        'username': 'newcomer', 'password1': 'a-fresh-password-1',
+        'password2': 'a-fresh-password-1'})
+    assert client.session.get('_auth_user_id')
+
+
+@pytest.mark.django_db
+def test_a_weak_password_is_refused(client, django_user_model):
+    config.SOPDS_ALLOW_REGISTRATION = True
+    resp = client.post(reverse('web:register'), {
+        'username': 'newcomer', 'password1': '123', 'password2': '123'})
+
+    assert resp.status_code == 200        # redisplayed with errors
+    assert not django_user_model.objects.filter(username='newcomer').exists()
+
+
+@pytest.mark.django_db
+def test_a_duplicate_username_is_refused(client, reader):
+    config.SOPDS_ALLOW_REGISTRATION = True
+    resp = client.post(reverse('web:register'), {
+        'username': 'reader', 'password1': 'a-fresh-password-1',
+        'password2': 'a-fresh-password-1'})
+    assert resp.status_code == 200
+    assert reader.check_password('old-password-42')     # untouched
+
+
+@pytest.mark.django_db
+def test_registration_is_throttled(client, django_user_model):
+    config.SOPDS_ALLOW_REGISTRATION = True
+    for n in range(10):
+        client.logout()
+        client.post(reverse('web:register'), {
+            'username': 'u%d' % n, 'password1': 'a-fresh-password-1',
+            'password2': 'a-fresh-password-1'})
+
+    client.logout()
+    resp = client.post(reverse('web:register'), {
+        'username': 'toomany', 'password1': 'a-fresh-password-1',
+        'password2': 'a-fresh-password-1'})
+    assert resp.status_code == 403
+    assert not django_user_model.objects.filter(username='toomany').exists()
+
+
+# --- mail configuration ----------------------------------------------------
+
+def test_mail_is_only_configured_when_it_could_work():
+    from sopds import email as mail
+
+    config.SOPDS_SMTP_HOST = 'smtp.example.com'
+    config.SOPDS_MAIL_FROM = 'library@example.com'
+    assert mail.is_configured()
+
+    config.SOPDS_SMTP_HOST = ''
+    assert not mail.is_configured()
+
+    config.SOPDS_SMTP_HOST = 'smtp.example.com'
+    config.SOPDS_MAIL_FROM = '   '
+    assert not mail.is_configured()
+
+
+def test_the_backend_takes_its_settings_from_the_admin():
+    from sopds.email import ConstanceEmailBackend
+
+    config.SOPDS_SMTP_HOST = 'mail.example.net'
+    config.SOPDS_SMTP_PORT = 2525
+    config.SOPDS_SMTP_USER = 'postman'
+    config.SOPDS_SMTP_TLS = False
+
+    backend = ConstanceEmailBackend()
+    assert (backend.host, backend.port, backend.username) == ('mail.example.net', 2525, 'postman')
+    assert backend.use_tls is False
+
+
+def test_an_explicit_argument_still_wins():
+    from sopds.email import ConstanceEmailBackend
+
+    config.SOPDS_SMTP_HOST = 'mail.example.net'
+    assert ConstanceEmailBackend(host='override.example.org').host == 'override.example.org'

--- a/opds_catalog/tests/test_constance.py
+++ b/opds_catalog/tests/test_constance.py
@@ -19,7 +19,7 @@ class constanceTestCase(TestCase):
         out = StringIO()
         call_command('constance', 'list', stdout=out)
         out.seek(0)
-        self.assertEqual(out.getvalue().count('\n'), 50)
+        self.assertEqual(out.getvalue().count('\n'), 58)
         out.close()
 
     def test_constance_set_get_attr(self):

--- a/sopds/email.py
+++ b/sopds/email.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+"""SMTP configured from the admin rather than from settings.
+
+Everything else an operator has to set here — the OIDC client, the Telegram
+token, the sync toggles, the metrics token — lives in constance and takes effect
+without a restart. Mail is configured the same way, so a password reset that
+does not arrive can be diagnosed and fixed in the admin rather than through a
+redeploy.
+
+Django reads `EMAIL_HOST` and friends from settings when a connection is opened,
+so making them dynamic means a backend that supplies them itself. This is that
+backend: the standard SMTP one with its parameters filled in from constance at
+connection time.
+"""
+import logging
+
+from django.core.mail.backends.smtp import EmailBackend as SMTPBackend
+
+from constance import config
+
+logger = logging.getLogger(__name__)
+
+
+def is_configured():
+    """Whether enough is set for mail to have any chance of being delivered.
+
+    Callers use this to hide features that would otherwise fail silently: an
+    offer to email a book to a device is worse than no offer at all if nothing
+    can send it.
+    """
+    return bool((config.SOPDS_SMTP_HOST or '').strip()
+                and (config.SOPDS_MAIL_FROM or '').strip())
+
+
+def from_address():
+    return (config.SOPDS_MAIL_FROM or '').strip()
+
+
+class ConstanceEmailBackend(SMTPBackend):
+    """`EmailBackend`, with host, port and credentials read from constance."""
+
+    def __init__(self, host=None, port=None, username=None, password=None,
+                 use_tls=None, use_ssl=None, **kwargs):
+        # Explicit arguments still win, so a test or a management command can
+        # pass its own; otherwise the admin's values are used.
+        super().__init__(
+            host=host if host is not None else (config.SOPDS_SMTP_HOST or '').strip(),
+            port=port if port is not None else config.SOPDS_SMTP_PORT,
+            username=username if username is not None else (config.SOPDS_SMTP_USER or '').strip(),
+            password=password if password is not None else (config.SOPDS_SMTP_PASSWORD or ''),
+            use_tls=use_tls if use_tls is not None else config.SOPDS_SMTP_TLS,
+            use_ssl=use_ssl if use_ssl is not None else config.SOPDS_SMTP_SSL,
+            **kwargs)

--- a/sopds/settings.py
+++ b/sopds/settings.py
@@ -237,6 +237,11 @@ else:
         }
     }
 
+# Mail goes through a backend that reads its host and credentials from constance,
+# so an operator fixes a failing password reset in the admin rather than through
+# a redeploy. See sopds/email.py.
+EMAIL_BACKEND = 'sopds.email.ConstanceEmailBackend'
+
 # Logging: tag every line with the request it belongs to. Several uwsgi workers
 # interleave their output and an e-reader polling feeds produces a lot of it, so
 # without the tag a report of "a download failed a few minutes ago" has to be
@@ -350,6 +355,16 @@ CONSTANCE_CONFIG = OrderedDict([
     ('SOPDS_OIDC_SCOPES', ('openid email profile', _('OIDC scopes (space-separated)'))),
     ('SOPDS_OIDC_BUTTON_TEXT', ('Log in with Keycloak', _('Text on the OIDC login button'))),
 
+    ('SOPDS_ALLOW_REGISTRATION', (False, _('Let visitors create their own account on the login page'))),
+
+    ('SOPDS_SMTP_HOST', ('', _('SMTP server for password resets and sending books to a device (empty = mail disabled)'))),
+    ('SOPDS_SMTP_PORT', (587, _('SMTP port'))),
+    ('SOPDS_SMTP_USER', ('', _('SMTP username'))),
+    ('SOPDS_SMTP_PASSWORD', ('', _('SMTP password'), 'password_input')),
+    ('SOPDS_SMTP_TLS', (True, _('Use STARTTLS'))),
+    ('SOPDS_SMTP_SSL', (False, _('Use implicit TLS (SMTPS). Mutually exclusive with STARTTLS.'))),
+    ('SOPDS_MAIL_FROM', ('', _('From address for outgoing mail'))),
+
     ('SOPDS_RATE_LIMIT', (600, _('Max requests per minute per reader for downloads, covers and the reader (0 = no limit)'))),
 
     ('SOPDS_METRICS_ENABLE', (False, _('Expose Prometheus metrics at /metrics'))),
@@ -372,7 +387,8 @@ CONSTANCE_CONFIG_FIELDSETS = {
     '7. Log & PID Files': ('SOPDS_SERVER_LOG', 'SOPDS_SCANNER_LOG', 'SOPDS_TELEBOT_LOG','SOPDS_SERVER_PID','SOPDS_SCANNER_PID','SOPDS_TELEBOT_PID'),
     '8. OIDC (Keycloak)': ('SOPDS_OIDC_ENABLE', 'SOPDS_OIDC_ISSUER', 'SOPDS_OIDC_CLIENT_ID', 'SOPDS_OIDC_CLIENT_SECRET', 'SOPDS_OIDC_SCOPES', 'SOPDS_OIDC_BUTTON_TEXT'),
     '9. Reading Progress Sync': ('SOPDS_KOSYNC_ENABLE', 'SOPDS_KOSYNC_ALLOW_REGISTER', 'SOPDS_WEBDAV_ENABLE', 'SOPDS_WEBDAV_ROOT'),
-    '10. Monitoring': ('SOPDS_RATE_LIMIT', 'SOPDS_METRICS_ENABLE', 'SOPDS_METRICS_TOKEN'),
+    '10. Accounts & Mail': ('SOPDS_ALLOW_REGISTRATION', 'SOPDS_SMTP_HOST', 'SOPDS_SMTP_PORT', 'SOPDS_SMTP_USER', 'SOPDS_SMTP_PASSWORD', 'SOPDS_SMTP_TLS', 'SOPDS_SMTP_SSL', 'SOPDS_MAIL_FROM'),
+    '11. Monitoring': ('SOPDS_RATE_LIMIT', 'SOPDS_METRICS_ENABLE', 'SOPDS_METRICS_TOKEN'),
 }
 
 

--- a/sopds_web_backend/templates/sopds_account_form.html
+++ b/sopds_web_backend/templates/sopds_account_form.html
@@ -1,0 +1,32 @@
+{# Shared shell for the account forms: one column, the form's own errors, a
+   submit button. They differ only in title, fields and button text. #}
+{% extends "sopds_main.html" %}
+{% load i18n %}
+
+{% block ext-body %}
+<div class="row">
+<div class="small-10 medium-6 large-4 small-centered columns">
+  <h4>{% block account_title %}{% endblock %}</h4>
+  {% block account_intro %}{% endblock %}
+
+  {% if form %}
+  <form method="post">
+    {% csrf_token %}
+    {% if form.non_field_errors %}
+      <div class="callout alert">{% for e in form.non_field_errors %}<p>{{ e }}</p>{% endfor %}</div>
+    {% endif %}
+    {% for field in form %}
+      <label>{{ field.label }}
+        {{ field }}
+      </label>
+      {% if field.help_text %}<p class="help-text" style="font-size:80%;opacity:.8;">{{ field.help_text|safe }}</p>{% endif %}
+      {% for e in field.errors %}<div class="callout alert" style="padding:.4rem;">{{ e }}</div>{% endfor %}
+    {% endfor %}
+    <input type="submit" class="button" value="{% block account_submit %}{% trans "Save" %}{% endblock %}">
+  </form>
+  {% endif %}
+
+  {% block account_after %}{% endblock %}
+</div>
+</div>
+{% endblock %}

--- a/sopds_web_backend/templates/sopds_login.html
+++ b/sopds_web_backend/templates/sopds_login.html
@@ -16,6 +16,12 @@
 </div>
 </div>
 </form>
+<div class="row">
+<div class="small-6 medium-4 large-3 small-centered columns" style="font-size:85%;">
+  {% if mail_configured %}<a href="{% url "web:password_reset" %}">{% trans "Forgot your password?" %}</a>{% endif %}
+  {% if allow_registration %}<br><a href="{% url "web:register" %}">{% trans "Create an account" %}</a>{% endif %}
+</div>
+</div>
 {% if oidc_enabled %}
 <div class="row">
 <div class="small-6 medium-4 large-3 small-centered columns text-center">

--- a/sopds_web_backend/templates/sopds_password_change.html
+++ b/sopds_web_backend/templates/sopds_password_change.html
@@ -1,0 +1,4 @@
+{% extends "sopds_account_form.html" %}
+{% load i18n %}
+{% block account_title %}{% trans "Change password" %}{% endblock %}
+{% block account_submit %}{% trans "Change password" %}{% endblock %}

--- a/sopds_web_backend/templates/sopds_password_change_done.html
+++ b/sopds_web_backend/templates/sopds_password_change_done.html
@@ -1,0 +1,5 @@
+{% extends "sopds_account_form.html" %}
+{% load i18n %}
+{% block account_title %}{% trans "Password changed" %}{% endblock %}
+{% block account_intro %}<p>{% trans "Your new password is in effect." %}</p>{% endblock %}
+{% block account_after %}<a class="button secondary" href="{% url "web:settings" %}">{% trans "Settings" %}</a>{% endblock %}

--- a/sopds_web_backend/templates/sopds_password_reset.html
+++ b/sopds_web_backend/templates/sopds_password_reset.html
@@ -1,0 +1,5 @@
+{% extends "sopds_account_form.html" %}
+{% load i18n %}
+{% block account_title %}{% trans "Reset password" %}{% endblock %}
+{% block account_intro %}<p>{% trans "Enter the address on your account and we will send you a link to set a new password." %}</p>{% endblock %}
+{% block account_submit %}{% trans "Send the link" %}{% endblock %}

--- a/sopds_web_backend/templates/sopds_password_reset_complete.html
+++ b/sopds_web_backend/templates/sopds_password_reset_complete.html
@@ -1,0 +1,5 @@
+{% extends "sopds_account_form.html" %}
+{% load i18n %}
+{% block account_title %}{% trans "Password set" %}{% endblock %}
+{% block account_intro %}<p>{% trans "You can now log in with your new password." %}</p>{% endblock %}
+{% block account_after %}<a class="button" href="{% url "web:login" %}">{% trans "Log in" %}</a>{% endblock %}

--- a/sopds_web_backend/templates/sopds_password_reset_confirm.html
+++ b/sopds_web_backend/templates/sopds_password_reset_confirm.html
@@ -1,0 +1,9 @@
+{% extends "sopds_account_form.html" %}
+{% load i18n %}
+{% block account_title %}{% trans "Set a new password" %}{% endblock %}
+{% block account_submit %}{% trans "Set password" %}{% endblock %}
+{% block account_intro %}
+  {% if not validlink %}
+    <div class="callout alert">{% trans "This link has already been used or has expired. Ask for a new one." %}</div>
+  {% endif %}
+{% endblock %}

--- a/sopds_web_backend/templates/sopds_password_reset_done.html
+++ b/sopds_web_backend/templates/sopds_password_reset_done.html
@@ -1,0 +1,8 @@
+{% extends "sopds_account_form.html" %}
+{% load i18n %}
+{% block account_title %}{% trans "Check your mail" %}{% endblock %}
+{% block account_intro %}
+{# Deliberately does not say whether an account exists for that address:
+   the reset form must not double as a way to find out who has one. #}
+<p>{% trans "If that address has an account, a link to set a new password is on its way. The link expires shortly." %}</p>
+{% endblock %}

--- a/sopds_web_backend/templates/sopds_password_reset_email.txt
+++ b/sopds_web_backend/templates/sopds_password_reset_email.txt
@@ -1,0 +1,8 @@
+{% load i18n %}{% autoescape off %}{% blocktrans %}Someone asked to reset the password for your account on {{ site_name }}.
+
+Open this link to set a new one:{% endblocktrans %}
+
+{{ protocol }}://{{ domain }}{% url 'web:password_reset_confirm' uidb64=uid token=token %}
+
+{% blocktrans %}The link works once and expires shortly. If it was not you, nothing has changed and you can ignore this message.{% endblocktrans %}
+{% endautoescape %}

--- a/sopds_web_backend/templates/sopds_password_reset_subject.txt
+++ b/sopds_web_backend/templates/sopds_password_reset_subject.txt
@@ -1,0 +1,1 @@
+{% load i18n %}{% blocktrans %}Set a new password for {{ site_name }}{% endblocktrans %}

--- a/sopds_web_backend/templates/sopds_register.html
+++ b/sopds_web_backend/templates/sopds_register.html
@@ -1,0 +1,4 @@
+{% extends "sopds_account_form.html" %}
+{% load i18n %}
+{% block account_title %}{% trans "Create an account" %}{% endblock %}
+{% block account_submit %}{% trans "Create account" %}{% endblock %}

--- a/sopds_web_backend/templates/sopds_settings.html
+++ b/sopds_web_backend/templates/sopds_settings.html
@@ -27,5 +27,7 @@
 
 		<button type="submit" class="button">{% trans "Save" %}</button>
 	</form>
+
+	<p style="margin-top:1rem;"><a href="{% url "web:password_change" %}">{% trans "Change password" %}</a></p>
 </div></div>
 {% endblock %}{# body #}

--- a/sopds_web_backend/urls.py
+++ b/sopds_web_backend/urls.py
@@ -1,5 +1,6 @@
 
-from django.urls import re_path
+from django.urls import re_path, reverse_lazy
+from django.contrib.auth import views as auth_views
 from sopds_web_backend import views
 
 app_name = 'opds_web_backend'
@@ -20,6 +21,23 @@ urlpatterns = [
     re_path(r'^settings/$',views.SettingsView, name='settings'),
     re_path(r'^sync/$',views.DeviceSyncView, name='devicesync'),
     re_path(r'^login/$',views.LoginView, name='login'),
+
+    # Self-service accounts. The reset flow is Django's own — the security is in
+    # the token generation and expiry, which is not worth reimplementing.
+    re_path(r'^register/$', views.RegisterView, name='register'),
+    re_path(r'^password/change/$', views.SopdsPasswordChangeView.as_view(), name='password_change'),
+    re_path(r'^password/change/done/$', auth_views.PasswordChangeDoneView.as_view(
+        template_name='sopds_password_change_done.html'), name='password_change_done'),
+    re_path(r'^password/reset/$', views.SopdsPasswordResetView.as_view(), name='password_reset'),
+    re_path(r'^password/reset/sent/$', auth_views.PasswordResetDoneView.as_view(
+        template_name='sopds_password_reset_done.html'), name='password_reset_done'),
+    re_path(r'^password/reset/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[^/]+)/$',
+            auth_views.PasswordResetConfirmView.as_view(
+                template_name='sopds_password_reset_confirm.html',
+                success_url=reverse_lazy('web:password_reset_complete')),
+            name='password_reset_confirm'),
+    re_path(r'^password/reset/done/$', auth_views.PasswordResetCompleteView.as_view(
+        template_name='sopds_password_reset_complete.html'), name='password_reset_complete'),
     re_path(r'^oidc/login/$',views.OIDCLoginView, name='oidc_login'),
     re_path(r'^oidc/callback/$',views.OIDCCallbackView, name='oidc_callback'),
     re_path(r'^logout/$',views.LogoutView, name='logout'),

--- a/sopds_web_backend/views.py
+++ b/sopds_web_backend/views.py
@@ -8,6 +8,8 @@ from django.db.models import Count, Min, Max, Prefetch
 from django.utils.translation import gettext as _
 from django.contrib.auth import authenticate, login, logout, REDIRECT_FIELD_NAME
 from django.contrib.auth.decorators import user_passes_test
+from django.contrib.auth import views as auth_views
+from django.contrib.auth.forms import UserCreationForm
 from django.views.decorators.vary import vary_on_headers
 from django.urls import reverse, reverse_lazy
 from django.utils.html import strip_tags
@@ -20,9 +22,10 @@ from opds_catalog.models import Book, Author, Series, bookshelf, Counter, Catalo
 from opds_catalog import settings
 from opds_catalog.utils import alphabet_menu, contains_page_ids, contains_page
 from book_tools.format.util import normalize_isbn
-from opds_catalog import dl, ratings, stats
+from opds_catalog import dl, ratings, stats, throttle
 from constance import config
 from sopds_web_backend import oidc
+from sopds import email as mail
 from opds_catalog.opds_paginator import Paginator as OPDS_Paginator
 
 
@@ -108,6 +111,9 @@ def sopds_processor(request):
     args['app_title'] = settings.TITLE
     args['sopds_auth'] = config.SOPDS_AUTH
     args['oidc_enabled'] = oidc.oidc_enabled()
+    args['allow_registration'] = config.SOPDS_ALLOW_REGISTRATION
+    # Offering a password reset that cannot be sent is worse than not offering it.
+    args['mail_configured'] = mail.is_configured()
     args['oidc_button_text'] = config.SOPDS_OIDC_BUTTON_TEXT
     args['sopds_version'] = settings.VERSION
     args['alphabet'] = config.SOPDS_ALPHABET_MENU
@@ -1168,6 +1174,124 @@ def BookReaderView(request, book_id):
     args['font_size'] = prefs.font_size
     args['css_file'] = prefs.theme_css
     return render(request, 'BookReader.html', args)
+
+
+# --- self-service accounts -------------------------------------------------
+#
+# Accounts could only be created, and passwords only changed, through the Django
+# admin. That is fine for one administrator and constant friction for everyone
+# else: a reader who forgot their password had to find a human.
+#
+# These lean on Django's own auth views for the parts where the security is in
+# the details — token generation and expiry for the reset flow, validator
+# enforcement for a new password — and only supply this project's chrome and a
+# throttle.
+
+
+def _account_form_args(request, **extra):
+    args = {'css_file': theme_css(request.user)}
+    args.update(csrf(request))
+    args.update(extra)
+    return args
+
+
+class SopdsPasswordChangeView(auth_views.PasswordChangeView):
+    template_name = 'sopds_password_change.html'
+    success_url = reverse_lazy('web:password_change_done')
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context.update(css_file=theme_css(self.request.user),
+                       breadcrumbs=[_('Settings'), _('Change password')])
+        return context
+
+
+class SopdsPasswordResetView(auth_views.PasswordResetView):
+    """Ask for a reset link.
+
+    Throttled on the same counter shape as the login form: this endpoint sends
+    mail to an address the caller chooses, which makes it usable both to spam a
+    stranger and to probe which addresses have accounts.
+    """
+    template_name = 'sopds_password_reset.html'
+    email_template_name = 'sopds_password_reset_email.txt'
+    subject_template_name = 'sopds_password_reset_subject.txt'
+    success_url = reverse_lazy('web:password_reset_done')
+
+    def dispatch(self, request, *args, **kwargs):
+        if not mail.is_configured():
+            raise Http404('mail is not configured')
+        if request.method == 'POST' and _reset_is_blocked(request):
+            return handler403(request, _account_form_args(
+                request, system_message={'text': _('Too many attempts. Please try again later.'),
+                                         'type': 'alert'}))
+        return super().dispatch(request, *args, **kwargs)
+
+    def form_valid(self, form):
+        _reset_register_attempt(self.request)
+        # Django's own view is what actually finds the user and sends the mail,
+        # and it deliberately reports success either way so this cannot be used
+        # to discover which addresses have accounts.
+        return super().form_valid(form)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context.update(css_file=theme_css(self.request.user),
+                       breadcrumbs=[_('Login'), _('Reset password')])
+        return context
+
+
+def RegisterView(request):
+    """Create an account, when the administrator has allowed it.
+
+    Off by default. A private library usually wants its accounts made for it,
+    and a registration form left open on the internet is a way to acquire
+    strangers.
+    """
+    if not config.SOPDS_ALLOW_REGISTRATION:
+        raise Http404('registration is disabled')
+
+    if request.user.is_authenticated:
+        return redirect(reverse('web:main'))
+
+    form = UserCreationForm(request.POST or None)
+    if request.method == 'POST':
+        if _reset_is_blocked(request):
+            return handler403(request, _account_form_args(
+                request, system_message={'text': _('Too many attempts. Please try again later.'),
+                                         'type': 'alert'}))
+        _reset_register_attempt(request)
+        if form.is_valid():
+            user = form.save()
+            login(request, user)
+            return redirect(reverse('web:main'))
+
+    return render(request, 'sopds_register.html',
+                  _account_form_args(request, form=form,
+                                     breadcrumbs=[_('Login'), _('Register')]))
+
+
+# Registration and password-reset attempts share one counter: both create work
+# for someone else (a row, or a message to an address the caller chose), and
+# both are worth limiting per client rather than per form.
+ACCOUNT_RATE_LIMIT = 10
+ACCOUNT_RATE_WINDOW = 600
+
+
+def _reset_key(request):
+    return 'ratelimit:account:%s' % throttle.client_id(request)
+
+
+def _reset_is_blocked(request):
+    return cache.get(_reset_key(request), 0) >= ACCOUNT_RATE_LIMIT
+
+
+def _reset_register_attempt(request):
+    key = _reset_key(request)
+    try:
+        cache.incr(key)
+    except ValueError:
+        cache.set(key, 1, ACCOUNT_RATE_WINDOW)
 
 
 def handler403(request, args):


### PR DESCRIPTION
A password could only be changed, and an account only created, through the Django admin. Workable for one administrator, constant friction for everyone else: a reader who forgot their password had to find a human with admin access.

## What is here

- **Change password** — linked from the settings page.
- **Forgotten password** — linked from the login page.
- **Registration** — behind `SOPDS_ALLOW_REGISTRATION`, **off by default**, because a registration form left open on the internet is a way to acquire strangers rather than readers.
- **Mail configured in the admin** — host, port, credentials, STARTTLS/SSL and the From address, through a backend that reads them when it opens a connection. A reset that does not arrive is then diagnosed and fixed in the admin, not through a redeploy. (Send-to-Kindle will reuse this.)

The reset and confirm steps are **Django's own auth views** wearing this project's chrome. Token generation, single use and expiry are where the security in that flow lives; reimplementing them would be all risk and no gain.

## Three choices rather than defaults

- The reset form **reports the same outcome for a known and an unknown address**, so it cannot double as a way to discover who has an account. Tested.
- It **404s when mail is unconfigured** and is not advertised on the login page then — an offer that cannot work is worse than no offer.
- Registration and reset **share one per-client throttle**. Both make work for somebody else (a row, or a message to an address the caller chose), and both are worth limiting per client rather than per form.

## Tests

`opds_catalog/tests/test_accounts.py`: 20 tests — changing a password, the old password being required, login required; the reset link actually setting a new password end to end, unknown addresses being indistinguishable, the flow hidden without mail, throttling; registration off by default and unadvertised, a visitor registering and being signed in, weak and duplicate rejections, throttling; and the mail backend reading constance with explicit arguments still winning.

577 tests pass, ruff clean.