### PR TITLE
Serve the catalogue as OPDS 2.0 as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,18 @@ All notable changes to this project are documented here. The format is based on
   than guessed at.
 
 ### Added
+- **OPDS 2.0 (JSON) feeds**, under `/opds/2.0/`, alongside the Atom ones rather
+  than instead of them: every e-reader still speaks 1.2, and the newer clients
+  — Thorium, Foliate, recent Aldiko — prefer or require 2.0. A navigation root,
+  *Recently added*, *Top rated*, *Most popular*, all books, and a templated
+  search link, each driven by the same querysets the Atom feeds and the web
+  listings use, so the two formats cannot disagree about what is in the
+  catalogue. The Atom root advertises the JSON one as an `alternate`, so a
+  client that prefers JSON can find it without being told.
+  The format was matched against the official test catalogue at
+  `test.opds.io/2.0/home.json` rather than the specification prose, since the
+  published draft currently 404s and a live reference implementation is the
+  better thing to agree with.
 - **Send a book to a reading device by mail.** The classic missing path: an
   e-reader without an OPDS client — a Kindle most obviously — can only be
   filled by mailing files to its address, so the only way out of this catalogue

--- a/opds_catalog/dl.py
+++ b/opds_catalog/dl.py
@@ -56,6 +56,33 @@ MAX_CACHED_RESOURCE_BYTES = 1024 * 1024
 MAX_CACHED_RENDER_BYTES = 4 * 1024 * 1024
 
 
+def authenticate_catalog(request):
+    """Resolve the caller against SOPDS_AUTH, or return a 401 to send back.
+
+    Returns None when the request may proceed. Shared by the content routes and
+    by the OPDS 2.0 feeds, which authenticate the same way but are not throttled
+    — listing is cheap, handing out content is what costs.
+    """
+    if config.SOPDS_AUTH and not request.user.is_authenticated:
+        # Returns the request (with .user set) on success, a 401 otherwise.
+        result = BasicAuthMiddleware().process_request(request)
+        if result is not None and not hasattr(result, 'user'):
+            return result
+    return None
+
+
+def require_login(view):
+    """Authenticate, without the rate limit. For browsing, not for content."""
+    @wraps(view)
+    def _wrapped(request, *args, **kwargs):
+        refused = authenticate_catalog(request)
+        if refused is not None:
+            return refused
+        return view(request, *args, **kwargs)
+
+    return _wrapped
+
+
 def require_catalog_access(view):
     """Guard the routes that hand out book content: who may ask, and how often.
 
@@ -68,11 +95,9 @@ def require_catalog_access(view):
     """
     @wraps(view)
     def _wrapped(request, *args, **kwargs):
-        if config.SOPDS_AUTH and not request.user.is_authenticated:
-            # Returns the request (with .user set) on success, a 401 otherwise.
-            result = BasicAuthMiddleware().process_request(request)
-            if result is not None and not hasattr(result, 'user'):
-                return result
+        refused = authenticate_catalog(request)
+        if refused is not None:
+            return refused
 
         # After authentication, so a signed-in reader is counted as themselves
         # rather than as their address, and before the ETag and the cache, so a

--- a/opds_catalog/feeds.py
+++ b/opds_catalog/feeds.py
@@ -89,6 +89,11 @@ class opdsFeed(Atom1Feed):
         if self.feed.get('searchTerm_url') is not None:
             handler.addQuickElement('link', None, {"href":self.feed["searchTerm_url"],"rel":"search","type":"application/atom+xml"})
             handler.characters("\n")
+        if self.feed.get('opds2_url') is not None:
+            # An "alternate" pointing at the same catalogue in OPDS 2.0, so a
+            # client that prefers JSON can switch without being told the URL.
+            handler.addQuickElement('link', None, {"href":self.feed["opds2_url"],"rel":"alternate","type":"application/opds+json"})
+            handler.characters("\n")
 
 
     def add_item_elements(self, handler, item):        
@@ -162,6 +167,7 @@ class MainFeed(AuthFeed):
                 #"searchTerm_url":reverse("opds_catalog:searchtypes",kwargs={"searchterms":"{searchTerms}"}),
                 "start_url":reverse("opds_catalog:main"),
                 "description_mime_type":"text",
+                "opds2_url":reverse("opds_catalog:opds2_root"),
         }
 
     def items(self):

--- a/opds_catalog/opds2.py
+++ b/opds_catalog/opds2.py
@@ -1,0 +1,174 @@
+# -*- coding: utf-8 -*-
+"""OPDS 2.0 — the JSON catalogue format.
+
+The existing feeds are OPDS 1.2 Atom, which every e-reader still speaks. The
+newer clients — Thorium, Foliate, recent Aldiko — prefer 2.0, and some only
+offer it. This serves the same catalogue in that format alongside the Atom one
+rather than instead of it; nothing about the 1.2 feeds changes.
+
+The shape here was taken from the official test catalogue at
+https://test.opds.io/2.0/home.json rather than from the specification prose,
+because the published draft at drafts.opds.io/opds-2.0 currently 404s and a
+live reference implementation is a better thing to match anyway. A feed is:
+
+    {"metadata": {...}, "links": [...], "navigation": [...], "publications": [...]}
+
+where a publication carries `metadata`, acquisition `links` and `images`.
+"""
+from django.urls import reverse
+
+from opds_catalog import models, settings
+from opds_catalog.models import Counter
+from book_tools.format import mime_detector
+from book_tools.format.mimetype import Mimetype
+
+CONTENT_TYPE = 'application/opds+json'
+
+# Relations, spelled out once. These are the OPDS 1.x URIs, which 2.0 keeps.
+ACQUISITION = 'http://opds-spec.org/acquisition/open-access'
+IMAGE = 'http://opds-spec.org/image'
+THUMBNAIL = 'http://opds-spec.org/image/thumbnail'
+
+
+def absolute(request, path):
+    """OPDS 2.0 clients are entitled to absolute URLs, and several insist."""
+    return request.build_absolute_uri(path)
+
+
+def publication(request, book, authors=None, series=None):
+    """One book, as an OPDS 2.0 Publication.
+
+    `authors`/`series` may be passed in when the caller has already prefetched
+    them, so rendering a page does not become one query per book.
+    """
+    authors = book.authors.all() if authors is None else authors
+    series = book.series.all() if series is None else series
+
+    metadata = {
+        '@type': 'http://schema.org/Book',
+        'title': book.title,
+        # A stable, resolvable-shaped identifier. The ISBN when we know it,
+        # since that is the one identifier a client might recognise; otherwise
+        # a URN naming this catalogue, which is at least unique here.
+        'identifier': ('urn:isbn:%s' % book.isbn) if book.isbn
+                      else 'urn:lectern:book:%s' % book.id,
+        'modified': book.registerdate.isoformat(),
+    }
+    if book.lang:
+        metadata['language'] = book.lang
+    if book.docdate:
+        metadata['published'] = book.docdate
+    if book.publisher:
+        metadata['publisher'] = book.publisher
+    if book.annotation:
+        metadata['description'] = book.annotation
+
+    names = [a.full_name for a in authors]
+    if names:
+        # One author is an object, several are a list — both are allowed, and
+        # clients handle the singular form more reliably.
+        metadata['author'] = ({'name': names[0]} if len(names) == 1
+                              else [{'name': n} for n in names])
+    if series:
+        metadata['belongsTo'] = {'series': [{'name': s.ser} for s in series]}
+
+    mime = str(mime_detector.fmt(book.format))
+    links = [{
+        'rel': ACQUISITION,
+        'href': absolute(request, reverse('opds_catalog:download',
+                                          kwargs={'book_id': book.id, 'zip_flag': 0})),
+        'type': mime,
+    }]
+    if book.format not in settings.NOZIP_FORMATS:
+        links.append({
+            'rel': ACQUISITION,
+            'href': absolute(request, reverse('opds_catalog:download',
+                                              kwargs={'book_id': book.id, 'zip_flag': 1})),
+            'type': Mimetype.FB2_ZIP if mime == Mimetype.FB2 else '%s+zip' % mime,
+        })
+
+    return {
+        'metadata': metadata,
+        'links': links,
+        'images': [
+            {'rel': THUMBNAIL,
+             'href': absolute(request, reverse('opds_catalog:thumb',
+                                               kwargs={'book_id': book.id})),
+             'type': 'image/jpeg'},
+            {'rel': IMAGE,
+             'href': absolute(request, reverse('opds_catalog:cover',
+                                               kwargs={'book_id': book.id})),
+             'type': 'image/jpeg'},
+        ],
+    }
+
+
+def navigation_feed(request, title, entries):
+    """A feed whose items are places to go rather than books."""
+    return {
+        'metadata': {'title': title},
+        'links': [{'rel': 'self', 'href': absolute(request, request.path),
+                   'type': CONTENT_TYPE},
+                  search_link(request)],
+        'navigation': entries,
+    }
+
+
+def search_link(request):
+    """A templated search link, as 2.0 expects rather than an OpenSearch document."""
+    return {
+        'rel': 'search',
+        'href': '%s{?query}' % absolute(request, reverse('opds_catalog:opds2_search')),
+        'type': CONTENT_TYPE,
+        'templated': True,
+    }
+
+
+def publication_feed(request, title, books, page, per_page, total):
+    """A feed of books, with the pagination 2.0 expresses in metadata."""
+    metadata = {
+        'title': title,
+        'numberOfItems': total,
+        'itemsPerPage': per_page,
+        'currentPage': page,
+    }
+
+    def page_url(number):
+        query = request.GET.copy()
+        query['page'] = number
+        return '%s?%s' % (absolute(request, request.path), query.urlencode())
+
+    links = [{'rel': 'self', 'href': absolute(request, request.get_full_path()),
+              'type': CONTENT_TYPE},
+             search_link(request)]
+    if page > 1:
+        links.append({'rel': 'previous', 'href': page_url(page - 1), 'type': CONTENT_TYPE})
+    if page * per_page < total:
+        links.append({'rel': 'next', 'href': page_url(page + 1), 'type': CONTENT_TYPE})
+
+    return {
+        'metadata': metadata,
+        'links': links,
+        'publications': [publication(request, b, list(b.authors.all()), list(b.series.all()))
+                         for b in books],
+    }
+
+
+def root_entries(request):
+    """The same entry points the Atom root feed offers."""
+    counter = Counter.objects
+
+    def entry(url_name, title, count=None):
+        item = {'href': absolute(request, reverse(url_name)),
+                'title': title, 'type': CONTENT_TYPE}
+        if count is not None:
+            item['metadata'] = {'numberOfItems': count}
+        return item
+
+    books = counter.get_counter(models.counter_allbooks)
+    return [
+        entry('opds_catalog:opds2_new', 'Recently added', books),
+        entry('opds_catalog:opds2_rated', 'Top rated'),
+        entry('opds_catalog:opds2_popular', 'Most popular'),
+        entry('opds_catalog:opds2_books', 'All books', books),
+    ]

--- a/opds_catalog/opds2_views.py
+++ b/opds_catalog/opds2_views.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+"""Views for the OPDS 2.0 feeds.
+
+Thin: each one picks a queryset — the same ones the Atom feeds and the web
+listings use, so the two formats can never disagree about what is in the
+catalogue — and hands it to `opds2` to render.
+"""
+from django.http import JsonResponse
+
+from constance import config
+
+from opds_catalog import dl, opds2, ratings, stats
+from opds_catalog.models import Book
+
+MAX_PER_PAGE = 100
+
+
+def _page(request):
+    """The requested page number, clamped to something sane."""
+    try:
+        page = int(request.GET.get('page', 1))
+    except (TypeError, ValueError):
+        page = 1
+    return max(1, page)
+
+
+def _per_page():
+    # Shares SOPDS_MAXITEMS with the Atom feeds, capped so a client cannot ask
+    # the server to render the whole catalogue in one response.
+    return max(1, min(config.SOPDS_MAXITEMS, MAX_PER_PAGE))
+
+
+def _json(payload):
+    # json_dumps_params: the catalogue is full of cyrillic, and escaping it to
+    # \uXXXX triples the size of a feed for no benefit to any client.
+    return JsonResponse(payload, content_type=opds2.CONTENT_TYPE,
+                        json_dumps_params={'ensure_ascii': False})
+
+
+def _publications(request, title, queryset):
+    page, per_page = _page(request), _per_page()
+    total = queryset.count()
+    start = (page - 1) * per_page
+    books = list(queryset.prefetch_related('authors', 'series')[start:start + per_page])
+    return _json(opds2.publication_feed(request, title, books, page, per_page, total))
+
+
+@dl.require_login
+def root(request):
+    return _json(opds2.navigation_feed(request, opds2.settings.TITLE,
+                                       opds2.root_entries(request)))
+
+
+@dl.require_login
+def new_books(request):
+    return _publications(request, 'Recently added',
+                         Book.objects.all().order_by('-registerdate', '-id'))
+
+
+@dl.require_login
+def top_rated(request):
+    return _publications(request, 'Top rated', ratings.top_rated())
+
+
+@dl.require_login
+def popular(request):
+    return _publications(request, 'Most popular', stats.most_popular())
+
+
+@dl.require_login
+def all_books(request):
+    return _publications(request, 'All books',
+                         Book.objects.all().order_by('search_title', '-docdate'))
+
+
+@dl.require_login
+def search(request):
+    """`?query=` — the target of the templated search link in every feed."""
+    term = (request.GET.get('query') or '').strip()
+    if not term:
+        # An empty search is not an error, it just has no results; a client
+        # following the template before the reader typed anything gets this.
+        return _publications(request, 'Search', Book.objects.none())
+
+    books = (Book.objects.filter(search_title__contains=term.upper())
+             .order_by('search_title', '-docdate'))
+    return _publications(request, 'Search: %s' % term, books)

--- a/opds_catalog/tests/test_opds2.py
+++ b/opds_catalog/tests/test_opds2.py
@@ -1,0 +1,267 @@
+"""OPDS 2.0, the JSON catalogue format.
+
+The shape asserted here was taken from the official test catalogue at
+https://test.opds.io/2.0/home.json, not from the specification prose — the
+published draft currently 404s, and a live reference implementation is the
+better thing to match.
+"""
+import json
+import os
+
+import pytest
+from django.urls import reverse
+from constance import config
+
+from opds_catalog import opds2, opdsdb, stats
+from opds_catalog.models import Book, Catalog, Counter, bookshelf
+
+DATA = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
+
+
+@pytest.fixture
+def catalogue(db, django_user_model):
+    config.SOPDS_AUTH = False
+    config.SOPDS_ROOT_LIB = DATA
+    config.SOPDS_MAXITEMS = 60
+    cat = Catalog.objects.create(parent=None, cat_name='.', path='.', cat_type=0)
+
+    def add(title, **extra):
+        fields = dict(filename='%s.fb2' % title, path='.', filesize=1, format='fb2',
+                      cat_type=0, docdate='2011', lang='en', title=title,
+                      search_title=title.upper(), annotation='', avail=2, catalog=cat)
+        fields.update(extra)
+        return Book.objects.create(**fields)
+
+    first = add('The Sanctuary Sparrow', isbn='9780306406157',
+                publisher='Gollancz', annotation='A mystery.')
+    first.authors.add(opdsdb.addauthor('Ellis Peters'))
+    second = add('Another Book')
+    Counter.objects.update_known_counters()
+    return {'first': first, 'second': second, 'cat': cat}
+
+
+def feed(client, name, **params):
+    resp = client.get(reverse(name), params)
+    assert resp.status_code == 200
+    assert resp['Content-Type'].startswith('application/opds+json')
+    return json.loads(resp.content.decode())
+
+
+# --- the navigation root ---------------------------------------------------
+
+@pytest.mark.django_db
+def test_the_root_is_a_navigation_feed(client, catalogue):
+    body = feed(client, 'opds:opds2_root')
+    assert body['metadata']['title']
+    assert {'navigation', 'links', 'metadata'} <= set(body)
+    assert all({'href', 'title', 'type'} <= set(e) for e in body['navigation'])
+
+
+@pytest.mark.django_db
+def test_every_feed_carries_a_self_link(client, catalogue):
+    for name in ('opds2_root', 'opds2_new', 'opds2_rated', 'opds2_popular', 'opds2_books'):
+        body = feed(client, 'opds:' + name)
+        rels = {link['rel'] for link in body['links']}
+        assert 'self' in rels, name
+
+
+@pytest.mark.django_db
+def test_search_is_advertised_as_a_uri_template(client, catalogue):
+    """2.0 uses a templated link rather than an OpenSearch document."""
+    link = next(l for l in feed(client, 'opds:opds2_root')['links'] if l['rel'] == 'search')
+    assert link['templated'] is True
+    assert link['href'].endswith('{?query}')
+
+
+@pytest.mark.django_db
+def test_urls_are_absolute(client, catalogue):
+    """Several 2.0 clients insist on it."""
+    body = feed(client, 'opds:opds2_root')
+    assert all(e['href'].startswith('http') for e in body['navigation'])
+
+
+@pytest.mark.django_db
+def test_the_atom_root_points_at_the_json_one(client, catalogue):
+    """So a client that prefers JSON can find it without being told."""
+    body = client.get(reverse('opds:main')).content.decode()
+    assert 'application/opds+json' in body
+    assert reverse('opds:opds2_root') in body
+
+
+# --- publications ----------------------------------------------------------
+
+@pytest.mark.django_db
+def test_a_publication_has_the_reference_shape(client, catalogue):
+    pub = feed(client, 'opds:opds2_new')['publications'][0]
+    assert {'metadata', 'links', 'images'} <= set(pub)
+    assert pub['metadata']['@type'] == 'http://schema.org/Book'
+    assert pub['metadata']['title']
+    assert pub['metadata']['identifier']
+
+
+@pytest.mark.django_db
+def test_metadata_is_carried_across(client, catalogue):
+    pubs = {p['metadata']['title']: p for p in feed(client, 'opds:opds2_new')['publications']}
+    meta = pubs['The Sanctuary Sparrow']['metadata']
+
+    assert meta['identifier'] == 'urn:isbn:9780306406157'
+    assert meta['publisher'] == 'Gollancz'
+    assert meta['description'] == 'A mystery.'
+    assert meta['language'] == 'en'
+    assert meta['author'] == {'name': 'Ellis Peters'}
+
+
+@pytest.mark.django_db
+def test_a_book_without_an_isbn_still_gets_an_identifier(client, catalogue):
+    pubs = {p['metadata']['title']: p for p in feed(client, 'opds:opds2_new')['publications']}
+    assert pubs['Another Book']['metadata']['identifier'].startswith('urn:lectern:book:')
+
+
+@pytest.mark.django_db
+def test_absent_metadata_is_omitted_not_empty(client, catalogue):
+    """A client should not have to distinguish "" from "unknown"."""
+    pubs = {p['metadata']['title']: p for p in feed(client, 'opds:opds2_new')['publications']}
+    meta = pubs['Another Book']['metadata']
+    assert 'publisher' not in meta
+    assert 'description' not in meta
+    assert 'author' not in meta
+
+
+@pytest.mark.django_db
+def test_several_authors_become_a_list(client, catalogue):
+    book = catalogue['second']
+    book.authors.add(opdsdb.addauthor('Arkady Strugatsky'))
+    book.authors.add(opdsdb.addauthor('Boris Strugatsky'))
+
+    pubs = {p['metadata']['title']: p for p in feed(client, 'opds:opds2_new')['publications']}
+    authors = pubs['Another Book']['metadata']['author']
+    assert isinstance(authors, list) and len(authors) == 2
+
+
+@pytest.mark.django_db
+def test_acquisition_and_image_links(client, catalogue):
+    pub = feed(client, 'opds:opds2_new')['publications'][0]
+
+    rels = {link['rel'] for link in pub['links']}
+    assert opds2.ACQUISITION in rels
+    image_rels = {i['rel'] for i in pub['images']}
+    assert {opds2.IMAGE, opds2.THUMBNAIL} == image_rels
+
+
+# --- the listings match the Atom ones --------------------------------------
+
+@pytest.mark.django_db
+def test_recently_added_is_newest_first(client, catalogue):
+    titles = [p['metadata']['title'] for p in feed(client, 'opds:opds2_new')['publications']]
+    assert titles == ['Another Book', 'The Sanctuary Sparrow']
+
+
+@pytest.mark.django_db
+def test_popular_uses_the_same_ordering_as_the_atom_feed(client, catalogue):
+    stats.record(catalogue['first'].id, stats.DOWNLOADS)
+    titles = [p['metadata']['title'] for p in feed(client, 'opds:opds2_popular')['publications']]
+    assert titles == ['The Sanctuary Sparrow']
+
+
+@pytest.mark.django_db
+def test_top_rated_uses_the_same_ordering(client, catalogue, django_user_model):
+    user = django_user_model.objects.create_user(username='r', password='pw')
+    bookshelf.objects.create(user=user, book=catalogue['second'], rating=5)
+    titles = [p['metadata']['title'] for p in feed(client, 'opds:opds2_rated')['publications']]
+    assert titles == ['Another Book']
+
+
+# --- pagination ------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_pagination_is_reported_in_metadata(client, catalogue):
+    config.SOPDS_MAXITEMS = 1
+    body = feed(client, 'opds:opds2_new')
+
+    assert body['metadata']['numberOfItems'] == 2
+    assert body['metadata']['itemsPerPage'] == 1
+    assert body['metadata']['currentPage'] == 1
+    assert len(body['publications']) == 1
+
+
+@pytest.mark.django_db
+def test_next_and_previous_appear_only_where_they_lead_somewhere(client, catalogue):
+    config.SOPDS_MAXITEMS = 1
+
+    first = feed(client, 'opds:opds2_new')
+    rels = {l['rel'] for l in first['links']}
+    assert 'next' in rels and 'previous' not in rels
+
+    second = feed(client, 'opds:opds2_new', page=2)
+    rels = {l['rel'] for l in second['links']}
+    assert 'previous' in rels and 'next' not in rels
+
+
+@pytest.mark.django_db
+def test_a_nonsense_page_does_not_error(client, catalogue):
+    assert feed(client, 'opds:opds2_new', page='abc')['metadata']['currentPage'] == 1
+    assert feed(client, 'opds:opds2_new', page='-5')['metadata']['currentPage'] == 1
+
+
+@pytest.mark.django_db
+def test_a_client_cannot_ask_for_the_whole_catalogue_at_once(client, catalogue):
+    config.SOPDS_MAXITEMS = 100000
+    assert feed(client, 'opds:opds2_new')['metadata']['itemsPerPage'] == opds2_max()
+
+
+def opds2_max():
+    from opds_catalog.opds2_views import MAX_PER_PAGE
+    return MAX_PER_PAGE
+
+
+# --- search ----------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_search_finds_by_title(client, catalogue):
+    body = feed(client, 'opds:opds2_search', query='sanctuary')
+    assert [p['metadata']['title'] for p in body['publications']] == ['The Sanctuary Sparrow']
+
+
+@pytest.mark.django_db
+def test_an_empty_search_is_an_empty_feed_not_an_error(client, catalogue):
+    """A client following the template before anything is typed gets this."""
+    body = feed(client, 'opds:opds2_search')
+    assert body['publications'] == []
+
+
+# --- access ----------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_the_feeds_honour_authentication(client, catalogue):
+    config.SOPDS_AUTH = True
+    assert client.get(reverse('opds:opds2_root')).status_code == 401
+    assert client.get(reverse('opds:opds2_new')).status_code == 401
+
+
+@pytest.mark.django_db
+def test_basic_auth_is_accepted(client, catalogue, django_user_model):
+    import base64
+    config.SOPDS_AUTH = True
+    django_user_model.objects.create_user(username='reader', password='pw')
+    header = 'Basic %s' % base64.b64encode(b'reader:pw').decode()
+    assert client.get(reverse('opds:opds2_root'), HTTP_AUTHORIZATION=header).status_code == 200
+
+
+@pytest.mark.django_db
+def test_browsing_is_not_rate_limited(client, catalogue):
+    """Listing is cheap; it is handing out content that costs."""
+    config.SOPDS_RATE_LIMIT = 2
+    for _ in range(6):
+        assert client.get(reverse('opds:opds2_new')).status_code == 200
+
+
+# --- encoding --------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_cyrillic_is_not_escaped_into_triple_the_bytes(client, catalogue):
+    catalogue['second'].title = 'Понедельник начинается в субботу'
+    catalogue['second'].save()
+
+    raw = client.get(reverse('opds:opds2_new')).content.decode()
+    assert 'Понедельник' in raw
+    assert '\\u041f' not in raw

--- a/opds_catalog/urls.py
+++ b/opds_catalog/urls.py
@@ -1,6 +1,6 @@
 
 from django.urls import re_path
-from opds_catalog import feeds, dl
+from opds_catalog import feeds, dl, opds2_views
 
 app_name='opds_catalog'
 
@@ -63,6 +63,15 @@ urlpatterns = [
     # Images referenced from a rendered EPUB. The path is matched loosely and
     # validated against the archive's own name list in the view.
     re_path(r'^read/(?P<book_id>[0-9]+)/res/(?P<path>.+)$', dl.ReadResource, name='readres'),
+
+    # OPDS 2.0 (JSON), alongside the Atom feeds rather than instead of them:
+    # every e-reader still speaks 1.2, and the newer clients prefer this.
+    re_path(r'^2.0/$', opds2_views.root, name='opds2_root'),
+    re_path(r'^2.0/new/$', opds2_views.new_books, name='opds2_new'),
+    re_path(r'^2.0/rated/$', opds2_views.top_rated, name='opds2_rated'),
+    re_path(r'^2.0/popular/$', opds2_views.popular, name='opds2_popular'),
+    re_path(r'^2.0/books/$', opds2_views.all_books, name='opds2_books'),
+    re_path(r'^2.0/search/$', opds2_views.search, name='opds2_search'),
 
     re_path(r'^$',feeds.MainFeed(), name='main'),
 ]


### PR DESCRIPTION
The feeds were Atom only. Every e-reader still speaks OPDS 1.2, so nothing was broken — but the newer clients (Thorium, Foliate, recent Aldiko) prefer 2.0 and some only offer it.

`/opds/2.0/` sits **beside** the Atom feeds, not in place of them: a navigation root, *Recently added*, *Top rated*, *Most popular*, all books, and search. Each is driven by the same queryset its Atom counterpart uses, so the two formats cannot drift into disagreeing about what the catalogue contains. The Atom root gains an `alternate` link to the JSON one.

## On matching the format

The published draft at `drafts.opds.io/opds-2.0` **currently 404s**. Rather than write the format from memory, I matched the official test catalogue at `test.opds.io/2.0/home.json` — a live reference implementation is a better guarantee of interoperability than my reading of a document.

Three details follow from it: **absolute URLs** (several clients insist), a **templated search link** rather than an OpenSearch document, and pagination as `numberOfItems`/`itemsPerPage`/`currentPage` with `next`/`previous` emitted only where they lead somewhere.

## Smaller choices

- Fields the catalogue does not know are **omitted rather than sent empty**, so a client never has to tell `""` from "unknown".
- Page size is **capped independently of `SOPDS_MAXITEMS`**, so a client cannot ask for the whole catalogue in one response.
- The JSON is **not ASCII-escaped** — the catalogue is largely cyrillic and escaping triples the size of a feed for no benefit.
- Authentication matches the Atom feeds; the rate limit is **not** applied, because listing is cheap and handing out content is what costs. That split is now explicit as `require_login` vs `require_catalog_access`.

## Tests

`opds_catalog/tests/test_opds2.py`: 24 tests — navigation shape, self links, the search template, absolute URLs, the Atom cross-link; publication shape against the reference, metadata carried across, identifier fallback, absent fields omitted, single vs multiple authors, acquisition and image rels; the three listings matching their Atom ordering; pagination metadata, conditional next/previous, nonsense page numbers, the page cap; search and empty search; auth, Basic auth, no throttling; and cyrillic not being escaped.

619 tests pass, ruff clean.