### PR TITLE
Drop the file extension from a fallback book title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ All notable changes to this project are documented here. The format is based on
   New dependency: `Markdown`.
 
 ### Changed
+- Books in a format that carries no metadata — a PDF or a DjVu scan — no longer
+  keep the file extension in their title. `shuty-i-skomorokhi.djvu` was showing
+  up as the book's name on the card, in the feed and in the search index.
 - **The welcome page** no longer describes the catalogue as a fork of SOPDS and
   little else. It says what this one actually does now — reading in the browser,
   OPDS on a device, progress sync, shelves and tags and lists — and points at

--- a/book_tools/format/bookfile.py
+++ b/book_tools/format/bookfile.py
@@ -10,7 +10,11 @@ class BookFile(object):
         self.file = file
         self.mimetype = mimetype
         self.original_filename = original_filename
-        self.title = original_filename
+        # A format that carries no metadata — a PDF or a DjVu scan — is left
+        # with its filename as its title. Without the extension: ".pdf" in a
+        # book's title on the card, in the feed and in the search index is
+        # noise nobody meant to put there.
+        self.title = os.path.splitext(original_filename)[0] or original_filename
         self.description = None
         self.authors = []
         self.tags = []

--- a/book_tools/tests/test_fallback_title.py
+++ b/book_tools/tests/test_fallback_title.py
@@ -1,0 +1,46 @@
+"""What a book is called when the file says nothing.
+
+A PDF or a DjVu scan carries no metadata the scanner can read, so the filename
+is all there is. The extension is not part of the title.
+"""
+import io
+
+import pytest
+
+from book_tools.format.bookfile import BookFile
+from book_tools.format.mimetype import Mimetype
+
+
+class Plain(BookFile):
+    """The base class is abstract only in its teardown."""
+
+    def __exit__(self, kind, value, traceback):
+        pass
+
+
+def title_of(filename):
+    return Plain(io.BytesIO(b''), filename, Mimetype.PDF).title
+
+
+@pytest.mark.parametrize('filename, expected', [
+    ('Shuty i skomorokhi.djvu', 'Shuty i skomorokhi'),
+    ('Аквилонов. Не убий (1906).pdf', 'Аквилонов. Не убий (1906)'),
+    ('report.final.pdf', 'report.final'),
+])
+def test_the_extension_is_not_part_of_the_title(filename, expected):
+    assert title_of(filename) == expected
+
+
+def test_a_name_that_is_only_an_extension_is_kept_whole():
+    """Better an odd title than an empty one."""
+    assert title_of('.pdf') == '.pdf'
+
+
+def test_a_name_without_an_extension_is_unchanged():
+    assert title_of('untitled') == 'untitled'
+
+
+def test_metadata_still_wins():
+    book = Plain(io.BytesIO(b''), 'whatever.pdf', Mimetype.PDF)
+    book.__set_title__('The Real Title')
+    assert book.title == 'The Real Title'


### PR DESCRIPTION
A PDF or a DjVu carries no metadata the scanner can read, so the filename is all there is to call the book by — but the extension is not part of the name.

A scan was appearing as `shuty-i-skomorokhi.djvu` on the book card, in the OPDS feed and in the search index. Now it is `shuty-i-skomorokhi`.

Metadata still wins wherever a format has any, so nothing changes for FB2, EPUB or MOBI. A filename that is *only* an extension keeps its name rather than becoming empty.

Noticed while seeding the demo installation, where the scans were the only books whose titles looked wrong.