### PR TITLE
Stop leaking template comments into rendered pages

### DIFF
--- a/sopds_web_backend/templates/sopds_account_form.html
+++ b/sopds_web_backend/templates/sopds_account_form.html
@@ -1,7 +1,7 @@
-{# Shared shell for the account forms: one column, the form's own errors, a
-   submit button. They differ only in title, fields and button text. #}
 {% extends "sopds_main.html" %}
 {% load i18n %}
+{% comment %} Shared shell for the account forms: one column, the form's own errors, a
+   submit button. They differ only in title, fields and button text. {% endcomment %}
 
 {% block ext-body %}
 <div class="row">

--- a/sopds_web_backend/templates/sopds_books.html
+++ b/sopds_web_backend/templates/sopds_books.html
@@ -24,8 +24,8 @@
 
  <button class="alert button small" type="button" onclick="document.getElementById('ConfirmModal').showModal()">{% trans "Clear bookshelf" %}</button>
 
- {# Reading status is set by hand and by an e-reader syncing progress, so the
-    shelf is worth narrowing by it. #}
+ {% comment %} Reading status is set by hand and by an e-reader syncing progress, so the
+    shelf is worth narrowing by it. {% endcomment %}
  <span class="lx-shelf-filter" style="margin-left:.6rem;font-size:85%;">
    <b>{% trans "Show:" %}</b>
    <a href="{% url "web:searchbooks" %}?searchtype=u"><span class="{% if not shelf_status %}label{% else %}secondary label{% endif %} small">{% trans "All" %}</span></a>
@@ -120,8 +120,8 @@
 				   <b>{% trans "Taken:" %}</b> <span class="label small">{% blocktrans count n=b.stat.downloads %}{{ n }} download{% plural %}{{ n }} downloads{% endblocktrans %}</span><br>
 				{% endif %}
 				{% if b.percent %}
-				   {# Reported by an e-reader over kosync; stored as a 0..1 fraction,
-				      and widthratio is the only stock way to scale it to percent. #}
+				   {% comment %} Reported by an e-reader over kosync; stored as a 0..1 fraction,
+				      and widthratio is the only stock way to scale it to percent. {% endcomment %}
 				   <b>{% trans "Progress:" %}</b> <span class="label small">{% widthratio b.percent 1 100 %}%</span><br>
 				{% endif %}
 				{% if sopds_auth %}

--- a/sopds_web_backend/templates/sopds_login.html
+++ b/sopds_web_backend/templates/sopds_login.html
@@ -3,8 +3,8 @@
 
 {% block ext-body %}
 {% if login_notice %}
-{# Whatever the administrator needs a visitor to read before they try to log
-   in: who to ask for an account, or the credentials of a public demo. #}
+{% comment %} Whatever the administrator needs a visitor to read before they try to log
+   in: who to ask for an account, or the credentials of a public demo. {% endcomment %}
 <div class="row">
 <div class="small-12 medium-8 large-6 small-centered columns">
   <div class="callout">{{ login_notice }}</div>

--- a/sopds_web_backend/templates/sopds_password_reset_done.html
+++ b/sopds_web_backend/templates/sopds_password_reset_done.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% block account_title %}{% trans "Check your mail" %}{% endblock %}
 {% block account_intro %}
-{# Deliberately does not say whether an account exists for that address:
-   the reset form must not double as a way to find out who has one. #}
+{% comment %} Deliberately does not say whether an account exists for that address:
+   the reset form must not double as a way to find out who has one. {% endcomment %}
 <p>{% trans "If that address has an account, a link to set a new password is on its way. The link expires shortly." %}</p>
 {% endblock %}

--- a/sopds_web_backend/tests/test_template_comments.py
+++ b/sopds_web_backend/tests/test_template_comments.py
@@ -14,7 +14,6 @@ import os
 import re
 
 import pytest
-from django.conf import settings
 
 ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -82,7 +81,7 @@ def test_no_page_renders_a_comment_marker(client, db, path):
     assert '{#' not in body and '#}' not in body, path
 
 
-def test_the_check_would_have_caught_it(tmp_path):
+def test_the_check_would_have_caught_it():
     """A guard nobody has seen fail is a guard nobody should trust."""
     broken = 'a {# one\nline too many #} b'
     assert spans_lines(broken, broken.index('{#'))

--- a/sopds_web_backend/tests/test_template_comments.py
+++ b/sopds_web_backend/tests/test_template_comments.py
@@ -1,0 +1,90 @@
+"""Comments in templates must actually be comments.
+
+Django's `{# ... #}` is single-line only: its lexer never looks past the end of
+the line, so a comment written across two lines is not a comment at all. It is
+emitted into the page verbatim, and it looks fine in the source — which is why
+this has now happened twice, once in the OpenSearch descriptor and once above
+the login form, where visitors were reading a note addressed to the
+administrator.
+
+`{% comment %} ... {% endcomment %}` spans lines. This walks every template in
+the repository rather than the handful currently known to be wrong.
+"""
+import os
+import re
+
+import pytest
+from django.conf import settings
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Third-party templates are not ours to fix.
+SKIP = ('.venv', 'node_modules', 'site-packages', os.path.join('constance', ''))
+
+
+def templates():
+    for base, dirs, names in os.walk(ROOT):
+        if any(part in base for part in SKIP):
+            continue
+        dirs[:] = [d for d in dirs if d not in ('.git', '.venv', 'node_modules')]
+        for name in names:
+            if name.endswith('.html'):
+                yield os.path.join(base, name)
+
+
+def spans_lines(text, start):
+    """True if the `{#` at `start` has no `#}` before the end of its line."""
+    close = text.find('#}', start)
+    line_end = text.find('\n', start)
+    return close == -1 or (line_end != -1 and close > line_end)
+
+
+def offenders():
+    found = []
+    for path in templates():
+        with open(path, encoding='utf-8', errors='replace') as f:
+            text = f.read()
+        for match in re.finditer(r'\{#', text):
+            if spans_lines(text, match.start()):
+                line = text[:match.start()].count('\n') + 1
+                found.append('%s:%d' % (os.path.relpath(path, ROOT), line))
+    return found
+
+
+def test_no_template_comment_spans_more_than_one_line():
+    found = offenders()
+    assert not found, (
+        'Django {# #} comments are single-line; these are emitted into the page. '
+        'Use {%% comment %%}...{%% endcomment %%}: %s' % ', '.join(found))
+
+
+@pytest.mark.django_db
+def test_the_login_page_does_not_leak_the_note_above_its_form(client):
+    """The one that got out."""
+    from constance import config
+    config.SOPDS_AUTH = True
+    config.SOPDS_LOGIN_NOTICE = 'Log in as demo / demo.'
+
+    body = client.get('/web/login/').content.decode()
+    assert 'Log in as demo / demo.' in body
+    assert 'the administrator' not in body
+    assert '{#' not in body and '#}' not in body
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('path', ['/web/', '/web/login/', '/web/register/', '/docs/'])
+def test_no_page_renders_a_comment_marker(client, db, path):
+    from constance import config
+    config.SOPDS_AUTH = False
+    config.SOPDS_ALLOW_REGISTRATION = True
+
+    body = client.get(path, follow=True).content.decode()
+    assert '{#' not in body and '#}' not in body, path
+
+
+def test_the_check_would_have_caught_it(tmp_path):
+    """A guard nobody has seen fail is a guard nobody should trust."""
+    broken = 'a {# one\nline too many #} b'
+    assert spans_lines(broken, broken.index('{#'))
+    fine = 'a {# all on one line #} b'
+    assert not spans_lines(fine, fine.index('{#'))


### PR DESCRIPTION
Django's `{# ... #}` is **single-line only** — the lexer never looks past the end of the line, so a comment written across two lines is not a comment at all. It is emitted into the page verbatim.

Visitors to the login page were reading a note addressed to the administrator, printed above the form:

> Whatever the administrator needs a visitor to read before they try to log in: who to ask for an account, or the credentials of a public demo.
> Демо-стенд Lectern. Войдите как demo / demo — …

Four more were doing the same on the book card, the account forms and the password-reset confirmation.

### Why a test rather than five fixes

It looks perfectly correct in the source, and this is the second time it has happened — the first was in the OpenSearch descriptor, caught then only because a test happened to assert on the output. So the guard walks **every** `.html` in the repository and fails on any `{#` that does not close on its own line, plus renders a few pages and checks for a stray marker. The helper that does the detection is itself tested against a known-bad and known-good string, because a guard nobody has seen fail is a guard nobody should trust.

### One non-cosmetic move

In `sopds_account_form.html` the comment had to move *below* `{% extends %}`: `{% comment %}` is a tag, and no tag may precede `{% extends %}`. As raw text it was tolerated there; as a real comment it is not.

752 pass.