### PR TITLE
Add Markdown to the test requirements

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -16,6 +16,8 @@ django-picklefield
 six
 Authlib
 requests
+# The /docs views import it to render the pages, so the suite needs it too.
+Markdown
 
 pytest==9.1.1
 pytest-django==4.12.0


### PR DESCRIPTION
CI has been red since #97. `Markdown` went into `requirements.txt` but not `requirements-test.txt`, so the eight tests that render a documentation page error with `ModuleNotFoundError: No module named 'markdown'`.

It passed locally because the local environment had the package installed by hand — which is exactly the drift `requirements-test.txt` exists to prevent.

Verified in a throwaway virtualenv built only from `requirements-test.txt`, running the same command the workflow does: 752 passed, 1 skipped, coverage 78.92%.