### PR TITLE
Keep the footer at the bottom of the window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,13 @@ All notable changes to this project are documented here. The format is based on
   A page missing from a translation falls back to English instead of 404ing.
   New dependency: `Markdown`.
 
+### Fixed
+- The footer no longer hangs in mid-air on a short page. On the login form, an
+  empty search or the welcome page it sat wherever the content happened to end,
+  with the page background below it to the bottom of the window. The page is now
+  at least as tall as the viewport and the content between the nav and the
+  footer absorbs the slack.
+
 ### Changed
 - Books in a format that carries no metadata — a PDF or a DjVu scan — no longer
   keep the file extension in their title. `shuty-i-skomorokhi.djvu` was showing

--- a/static/css/lectern.css
+++ b/static/css/lectern.css
@@ -95,6 +95,21 @@ body {
   background: var(--bg);
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
+
+  /* The page is at least as tall as the window, and the content between the
+     nav and the footer takes up whatever is left over — so on a short page
+     (the login form, an empty search) the footer sits on the bottom edge
+     instead of halfway up with nothing under it. */
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+/* A mobile browser's viewport grows as the address bar retracts; 100vh is the
+   larger of the two and leaves the page scrollable by that much. dvh follows
+   the real height. */
+@supports (min-height: 100dvh) {
+  body { min-height: 100dvh; }
 }
 
 a { color: var(--link); text-decoration: none; }
@@ -637,9 +652,12 @@ dialog.reveal::backdrop { background: rgba(15, 20, 15, .45); }
 /* --------------------------------------------------------------------------
    14. Content wrapper + footer
    -------------------------------------------------------------------------- */
-.content-wrap { max-width: var(--maxw); margin: 0 auto; padding: 1.25rem 0 2rem; }
+/* `width: 100%` because body is a flex column: an item with auto margins on the
+   cross axis is not stretched, so without it the wrapper would shrink to its
+   contents instead of filling the column up to --maxw. */
+.content-wrap { max-width: var(--maxw); width: 100%; margin: 0 auto; padding: 1.25rem 0 2rem; flex: 1 0 auto; }
 
-.lx-footer { background: var(--surface-2); border-top: 1px solid var(--border); margin-top: 2rem; }
+.lx-footer { background: var(--surface-2); border-top: 1px solid var(--border); margin-top: 2rem; flex-shrink: 0; }
 .lx-footer .footer-grid { max-width: var(--maxw); margin: 0 auto; padding: 1.5rem var(--gutter) .5rem; }
 .lx-footer h5 { font-size: .8rem; letter-spacing: .06em; text-transform: uppercase; color: var(--text-muted); }
 .lx-footer .menu { list-style: none; display: flex; margin: 0; padding: 0; }


### PR DESCRIPTION
On a short page — the login form, an empty search, the welcome page — the footer sat wherever the content happened to end, with page background below it down to the bottom of the window.

The page is now at least as tall as the viewport, laid out as a column, and the content wrapper takes up whatever is left between the nav and the footer.

### Two details that are not obvious

- **`.content-wrap` needs an explicit `width: 100%`.** `body` is now a flex container, and a flex item with `auto` margins on the cross axis is *not* stretched — without it the wrapper would shrink to its contents instead of filling the column up to `--maxw`.
- **`100dvh` where supported.** A mobile browser's viewport grows as the address bar retracts; `100vh` is the larger of the two and would leave every page scrollable by exactly that much.

### Verified in headless Chrome

Measured `scrollHeight`, `innerHeight` and the footer's `getBoundingClientRect().bottom` at 1280×900 (viewport 813):

| page | result |
|---|---|
| login | H=813, V=813, footer bottom **813** |
| welcome, full footer grid | H=831, footer bottom 831 |
| book listing, 17 books | H=4606, footer bottom 4606 |

Before the change the login page's footer ended around y=550 with 350px of empty background under it.

The short page is exactly the viewport height with **no** spurious scrollbar: flexbox counts the footer's `2rem` top margin when working out free space. Also checked at 390×844.

No automated test — this is layout, and CI has no browser.